### PR TITLE
chore: Change vendors to vendor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "vendors/hpx"]
-	path = vendors/hpx
+[submodule "vendor/hpx"]
+	path = vendor/hpx
 	url = https://github.com/STEllAR-GROUP/hpx

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,10 +61,10 @@ cmd = [
     "checkout",
     "{{ tag }}",
 ]
-cwd = "vendors/hpx"
+cwd = "vendor/hpx"
 
 [feature.hpx-latest.tasks]
-build = { cmd = ["../../scripts/build.sh"], cwd = "vendors/hpx" }
+build = { cmd = ["../../scripts/build.sh"], cwd = "vendor/hpx" }
 build-hpx-latest = { depends-on = ["set-hpx-version", "build"] }
 install-all = { cmd = 'pip install --verbose -e ".[all]"', depends-on = [
     "build-hpx-latest",

--- a/pixi.toml
+++ b/pixi.toml
@@ -52,6 +52,9 @@ mimalloc = ">=3.0.1,<4"
 gperftools = ">=2.10,<3"
 asio = ">=1.29.0,<2"
 
+[feature.hpx-latest.tasks.fetch-hpx-source]
+cmd = "git submodule update --init"
+
 [feature.hpx-latest.tasks.set-hpx-version]
 args = [
     { "arg" = "tag", "default" = "v1.11.0-rc1" },
@@ -62,6 +65,7 @@ cmd = [
     "{{ tag }}",
 ]
 cwd = "vendor/hpx"
+depends-on = ["fetch-hpx-source"]
 
 [feature.hpx-latest.tasks]
 build = { cmd = ["../../scripts/build.sh"], cwd = "vendor/hpx" }


### PR DESCRIPTION
This pull request makes adjustments to the naming convention of the `hpx` submodule directory to ensure consistency across the repository. The most important changes involve updating references to the directory from `vendors/hpx` to `vendor/hpx` in configuration files.

### Submodule directory updates:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-R2): Changed the submodule path from `vendors/hpx` to `vendor/hpx` to align with the updated naming convention.

### Configuration file updates:

* [`pixi.toml`](diffhunk://#diff-b092682f0ad15a352f9fa2b0a67c992454b586275ee76b74a5839ab9afdf9894L64-R67): Updated the `cwd` field in multiple tasks to reference `vendor/hpx` instead of `vendors/hpx`, ensuring consistency with the new directory name.