### PR TITLE
build: Add schema to pixi toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,7 @@
-[project]
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.49.0/schema/manifest/schema.json"
+
+[workspace]
 authors = ["Don Setiawan", "Ayush Nag", "Madeline Gordon", "Hartmut Kaiser"]
 channels = ["conda-forge"]
 description = "Python Binding for HPX C++ library"


### PR DESCRIPTION
This pull request makes a small update to the `pixi.toml` configuration file. The main change is the addition of a `$schema` field specifying the schema URL for validation and compatibility with newer versions of `pixi`.