### PR TITLE
build: Sync Pixi version to v0.49 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.14
         with:
-          pixi-version: v0.48.2
+          pixi-version: v0.49.0
           cache: true
       - name: Test package
         run: pixi run -e ${{ matrix.pixi-env }} test

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 "$schema" = "https://pixi.sh/v0.49.0/schema/manifest/schema.json"
 
 [workspace]
-requires-pixi = ">=0.48,<1.0"
+requires-pixi = ">=0.49,<1.0"
 authors = ["Don Setiawan", "Ayush Nag", "Madeline Gordon", "Hartmut Kaiser"]
 channels = ["conda-forge"]
 description = "Python Binding for HPX C++ library"


### PR DESCRIPTION
This pull request updates the project to use Pixi version 0.49.0. This ensures compatibility with the latest features and schema changes from Pixi.

Dependency and configuration updates:

* Updated the `pixi-version` used in the CI workflow in `.github/workflows/ci.yml` from `v0.48.2` to `v0.49.0` to ensure CI uses the latest Pixi version.
* Updated the `requires-pixi` constraint and schema reference in `pixi.toml` to require Pixi version `>=0.49,<1.0` and use the new schema URL for version 0.49.0.