### PR TITLE
feat(build): Add 'build-wheel-and-test' task to streamline wheel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
           cache: true
 
       - name: Build wheels
-        run: pixi run -e build-py313t build-wheel
+        run: pixi run -e build-py313t build-wheel-and-test
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/pixi.lock
+++ b/pixi.lock
@@ -4251,8 +4251,8 @@ packages:
   timestamp: 1754979013533
 - pypi: ./
   name: hpyx
-  version: 0.1.dev49
-  sha256: afe03a1fca1f42dbcdac7b64542cca76f3a7fc46fbbf39bdce8357c5055a2a55
+  version: 0.1.dev51
+  sha256: dbd2e9d4dadeae72bc35c4811692edb5ed59c1f58c8206b94158c88132d06d0d
   requires_dist:
   - numpy
   - pre-commit ; extra == 'dev'

--- a/pixi.toml
+++ b/pixi.toml
@@ -167,6 +167,21 @@ description = "Build source distribution package"
 [feature.build.tasks.build-wheel]
 cmd = ["python", "-m", "build", ".", "--wheel", "--outdir", "wheelhouse"]
 description = "Build wheel distribution package"
+
+[feature.build.tasks.build-wheel-and-test]
+depends-on = [
+    { "task" = "build-wheel" },
+    { "task" = "_install-wheel" },
+    { "task" = "_print-versions" },
+]
+
+[feature.build.tasks._install-wheel]
+cmd = "pip install --force-reinstall --verbose wheelhouse/*.whl"
+description = "Install the built wheel package"
+
+[feature.build.tasks._print-versions]
+cmd = "python -m hpyx.util.print_versions"
+description = "Print versions of all installed dependencies and the HPyX package"
 # === End Build Configuration ===
 
 # === Test Configuration ===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ sdist.exclude = [".pixi"]
 
 minimum-version = "build-system.requires"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["src/hpyx/_version.py"]
 
 # Pytest options
 [tool.pytest.ini_options]


### PR DESCRIPTION
This pull request updates the build workflow to improve reliability by ensuring the built wheel is installed and tested immediately after creation. The main change is replacing the previous wheel build step with a new composite task that builds the wheel, installs it, and prints version information. Supporting tasks are added to facilitate this process.

**Build workflow improvements:**

* The `Build wheels` step in `.github/workflows/cd.yml` now runs the new `build-wheel-and-test` task instead of just `build-wheel`, ensuring the wheel is both built and validated in the CI pipeline.

**New build tasks and validation steps:**

* Added the `build-wheel-and-test` task to `pixi.toml`, which depends on building the wheel, installing it, and printing version information for verification.
* Added `_install-wheel` task to install the newly built wheel using pip for immediate validation.
* Added `_print-versions` task to print the versions of all installed dependencies and the HPyX package, aiding in debugging and reproducibility.
