### PR TITLE
ci: Update test pypi cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,9 +94,17 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: List contents of built dist
+        run: |
+          ls -ltrh
+          ls -ltrh dist
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          skip-existing: true
 
   publish:
     needs: [build_wheels, build_sdist]


### PR DESCRIPTION
This pull request updates the continuous deployment workflow in `.github/workflows/cd.yml` to improve visibility into the build process and modify the publishing step. The changes add a listing of build artifacts before publishing and update the PyPI publishing step to target Test PyPI with additional options for verbosity and skipping existing packages.

**Continuous deployment workflow improvements:**

* Added a step to list the contents of the build output and the `dist` directory before publishing, improving visibility into what is being packaged.
* Updated the PyPI publishing step to use `pypa/gh-action-pypi-publish@v1.12.4`, set the repository to Test PyPI, enabled verbose output, and added the option to skip existing packages.