### PR TITLE
ci: Setup cibuildwheel to cover various architectures

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,22 +34,22 @@ jobs:
           - os: macos-intel
             # macos-13 was the last x86_64 runner
             runs-on: macos-13
-          - os: macos-14-arm
-            runs-on: macos-14
-          - os: macos-15-arm
-            runs-on: macos-15
+          - os: macos-arm
+            # macos-14+ (including latest) are ARM64 runners
+            runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
-      - uses: prefix-dev/setup-pixi@v0.9.0
-        with:
-          pixi-version: v0.49.0
-          cache: true
 
       - name: Build wheels
-        run: pixi run -e build-py313t build-wheel-and-test
+        uses: pypa/cibuildwheel@v2.17
+        env:
+          CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
       - name: Verify clean directory

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,9 +34,10 @@ jobs:
           - os: macos-intel
             # macos-13 was the last x86_64 runner
             runs-on: macos-13
-          - os: macos-arm
-            # macos-14+ (including latest) are ARM64 runners
-            runs-on: macos-latest
+          - os: macos-14-arm
+            runs-on: macos-14
+          - os: macos-15-arm
+            runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,10 @@ jobs:
         uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
       - name: Verify clean directory
         run: git diff --exit-code
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [build-system]
 build-backend = "scikit_build_core.build"
-requires = ["scikit-build-core >=0.9.5", "nanobind", "setuptools_scm >=8"]
+requires = [
+    "scikit-build-core >=0.9.5",
+    "nanobind",
+    "setuptools_scm >=8",
+    "cmake >=3.15,<3.29",
+]
 
 [project]
 name = "hpyx"
@@ -21,13 +26,7 @@ classifiers = [
 dependencies = ["numpy"]
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit",
-    "pytest>=8",
-    "pytest-cov",
-    "pytest-xdist",
-    "pytest-mock",
-]
+dev = ["pre-commit", "pytest>=8", "pytest-cov", "pytest-xdist", "pytest-mock"]
 docs = [
     "sphinx_rtd_theme",
     "sphinx-automodapi",
@@ -133,3 +132,13 @@ isort.required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
+
+[tool.cibuildwheel]
+enable = "cpython-freethreading"
+
+# [tool.cibuildwheel.environment]
+# PATH = "/project/.pixi/envs/cibuild/bin:$PATH"
+# HPX_DIR = "/project/.pixi/envs/cibuild/lib/cmake/HPX/"
+# Asio_ROOT = "/project/.pixi/envs/cibuild/include"
+# Hwloc_ROOT = "/project/.pixi/envs/cibuild/include"
+# Boost_ROOT = "/project/.pixi/envs/cibuild/lib"


### PR DESCRIPTION
This pull request updates the build and packaging workflow for the project, focusing on improving compatibility and reliability for Python wheels. The main changes are the switch to `cibuildwheel` for building wheels, the addition of explicit `cmake` version requirements, and configuration for CPython freethreading builds.

**Build system and workflow improvements:**

* Switched the GitHub Actions workflow from using `pixi` to the official `pypa/cibuildwheel` action for building Python wheels, improving cross-platform compatibility and reliability. Also added a step to verify a clean working directory after building. (`.github/workflows/cd.yml`)
* Added explicit `cmake` version requirements (`>=3.15,<3.29`) to the `pyproject.toml` to ensure consistent builds across environments.

**Configuration updates:**

* Added `[tool.cibuildwheel]` section to `pyproject.toml` to enable CPython freethreading builds, preparing the project for future Python concurrency improvements.

**Minor formatting changes:**

* Reformatted the `dev` dependencies list in `pyproject.toml` for improved readability.