### PR TITLE
ci: Adds support for manylinux

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,8 +55,9 @@ jobs:
         run: |
           for whl in wheelhouse/*.whl; do
             pixi run -e build-py313t auditwheel show "$whl"
-            pixi run -e build-py313t auditwheel-symbols "$whl"
             pixi run -e build-py313t auditwheel repair "$whl" --plat manylinux_2_39_x86_64 -w wheelhouse/
+            # Remove the original wheel
+            rm "$whl"
           done
           # List the repaired wheels
           ls -lh wheelhouse/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,6 +50,14 @@ jobs:
 
       - name: Build wheels
         run: pixi run -e build-py313t build-wheel-and-test
+      - name: Auditwheel repair (Linux only)
+        if: matrix.os == 'linux-intel'
+        run: |
+          for whl in wheelhouse/*.whl; do
+            pixi run -e build-py313t auditwheel repair "$whl" --plat manylinux_2_28_x86_64 -w wheelhouse/
+          done
+          # List the repaired wheels
+          ls -lh wheelhouse/
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,7 +56,7 @@ jobs:
           for whl in wheelhouse/*.whl; do
             pixi run -e build-py313t auditwheel show "$whl"
             pixi run -e build-py313t auditwheel-symbols "$whl"
-            pixi run -e build-py313t auditwheel repair "$whl" --plat manylinux_2_28_x86_64 -w wheelhouse/
+            pixi run -e build-py313t auditwheel repair "$whl" --plat manylinux_2_39_x86_64 -w wheelhouse/
           done
           # List the repaired wheels
           ls -lh wheelhouse/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,8 @@ jobs:
         if: matrix.os == 'linux-intel'
         run: |
           for whl in wheelhouse/*.whl; do
+            pixi run -e build-py313t auditwheel show "$whl"
+            pixi run -e build-py313t auditwheel-symbols "$whl"
             pixi run -e build-py313t auditwheel repair "$whl" --plat manylinux_2_28_x86_64 -w wheelhouse/
           done
           # List the repaired wheels

--- a/pixi.lock
+++ b/pixi.lock
@@ -335,6 +335,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asio-1.29.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/auditwheel-6.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.44-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-h4bf12b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.44-h4852527_1.conda
@@ -402,6 +403,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh707e725_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.5-h71033d7_2_cp313t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.13.5-h92d6c8b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313t.conda
@@ -423,6 +425,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asio-1.29.0-h53b3b88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/auditwheel-6.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.8.0-hfc4bf79_1.conda
@@ -483,6 +486,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh707e725_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.5-hbc1b2f2_2_cp313t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.13.5-h92d6c8b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313t.conda
@@ -505,6 +509,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/asio-1.29.0-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/auditwheel-6.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-hf48404e_1.conda
@@ -565,6 +570,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh707e725_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.5-hd53ec70_2_cp313t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.13.5-h92d6c8b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313t.conda
@@ -588,6 +594,7 @@ environments:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asio-1.29.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/auditwheel-6.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/clang-17-17.0.6-default_hec7ea82_8.conda
@@ -625,6 +632,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh7428d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.5-h9100add_2_cp313t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-freethreading-3.13.5-h92d6c8b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313t.conda
@@ -2953,6 +2961,19 @@ packages:
   - mypy>=1.11.1 ; python_full_version >= '3.10' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
   - pytest-mypy-plugins ; python_full_version >= '3.10' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/auditwheel-6.4.2-pyhd8ed1ab_0.conda
+  sha256: d4841de7ec59776d520f9811a603f4077f6fdb7eb2274da9825d59e45c1fdd2c
+  md5: c364239a2d8a6e20b8a54cfdab346767
+  depends:
+  - packaging >=20.9
+  - pyelftools >=0.24
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/auditwheel?source=hash-mapping
+  size: 46124
+  timestamp: 1753879913835
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   md5: 0a01c169f0ab0f91b26e77a3301fbfe4
@@ -7223,6 +7244,28 @@ packages:
   requires_dist:
   - typing-extensions>=4.6.0,!=4.7.0
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh707e725_1.conda
+  sha256: de3a334388959397ba7b69ee92d5dfaa0c1bd6a7ffcf49c3c4de2ac045c69d28
+  md5: eae78c632c980c396cf6f711cf515c3a
+  depends:
+  - __unix
+  - python >=3.9
+  license: Unlicense
+  purls:
+  - pkg:pypi/pyelftools?source=hash-mapping
+  size: 149336
+  timestamp: 1744148364068
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyelftools-0.32-pyh7428d3b_1.conda
+  sha256: 71aeaadc0ce2e04889ca763f8997ba3d4bcad910052dbbbdcbee456af087943a
+  md5: f5c9b7c2f0d0bf7d3f0e31c825e98d4a
+  depends:
+  - __win
+  - python >=3.9
+  license: Unlicense
+  purls:
+  - pkg:pypi/pyelftools?source=hash-mapping
+  size: 150034
+  timestamp: 1744148463901
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066

--- a/pixi.lock
+++ b/pixi.lock
@@ -421,6 +421,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - pypi: https://files.pythonhosted.org/packages/0f/51/ef3c391a84e7fbd7bdba37a9689d0269083eb3f4685d9729bdcdcea8bc48/auditwheel_symbols-0.1.13-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-64:
@@ -505,6 +506,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+      - pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-arm64:
@@ -589,6 +591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+      - pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       win-64:
@@ -652,6 +655,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+      - pypi: https://files.pythonhosted.org/packages/c9/2e/4bf53c7fb1b84f01148856bfc71dbc434cfa18cf83b7331243b0e11814d3/auditwheel_symbols-0.1.13-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2974,6 +2978,18 @@ packages:
   - pkg:pypi/auditwheel?source=hash-mapping
   size: 46124
   timestamp: 1753879913835
+- pypi: https://files.pythonhosted.org/packages/0f/51/ef3c391a84e7fbd7bdba37a9689d0269083eb3f4685d9729bdcdcea8bc48/auditwheel_symbols-0.1.13-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+  name: auditwheel-symbols
+  version: 0.1.13
+  sha256: 2a97e4bdeb2681f8d4d327d1356bfb8a7ba9344d5a0e4136afdd278c408bb04e
+- pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
+  name: auditwheel-symbols
+  version: 0.1.13
+  sha256: 6cc06ef838190d51b5ac367db2404b085c533fac50d375619f7510af5af8373f
+- pypi: https://files.pythonhosted.org/packages/c9/2e/4bf53c7fb1b84f01148856bfc71dbc434cfa18cf83b7331243b0e11814d3/auditwheel_symbols-0.1.13-py3-none-win_amd64.whl
+  name: auditwheel-symbols
+  version: 0.1.13
+  sha256: 1f3298d2cab4adc568d3b244fd01c696fd6ce99826ff17801e9870c961fdcfb4
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   md5: 0a01c169f0ab0f91b26e77a3301fbfe4

--- a/pixi.lock
+++ b/pixi.lock
@@ -421,7 +421,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/0f/51/ef3c391a84e7fbd7bdba37a9689d0269083eb3f4685d9729bdcdcea8bc48/auditwheel_symbols-0.1.13-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-64:
@@ -506,7 +505,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
-      - pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       osx-arm64:
@@ -591,7 +589,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       win-64:
@@ -655,7 +652,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/c9/2e/4bf53c7fb1b84f01148856bfc71dbc434cfa18cf83b7331243b0e11814d3/auditwheel_symbols-0.1.13-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2978,18 +2974,6 @@ packages:
   - pkg:pypi/auditwheel?source=hash-mapping
   size: 46124
   timestamp: 1753879913835
-- pypi: https://files.pythonhosted.org/packages/0f/51/ef3c391a84e7fbd7bdba37a9689d0269083eb3f4685d9729bdcdcea8bc48/auditwheel_symbols-0.1.13-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-  name: auditwheel-symbols
-  version: 0.1.13
-  sha256: 2a97e4bdeb2681f8d4d327d1356bfb8a7ba9344d5a0e4136afdd278c408bb04e
-- pypi: https://files.pythonhosted.org/packages/10/78/0a94584ab08eddf9f887ef2b150937633a6236cd5b036f4d5e39a0fe875b/auditwheel_symbols-0.1.13-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl
-  name: auditwheel-symbols
-  version: 0.1.13
-  sha256: 6cc06ef838190d51b5ac367db2404b085c533fac50d375619f7510af5af8373f
-- pypi: https://files.pythonhosted.org/packages/c9/2e/4bf53c7fb1b84f01148856bfc71dbc434cfa18cf83b7331243b0e11814d3/auditwheel_symbols-0.1.13-py3-none-win_amd64.whl
-  name: auditwheel-symbols
-  version: 0.1.13
-  sha256: 1f3298d2cab4adc568d3b244fd01c696fd6ce99826ff17801e9870c961fdcfb4
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   md5: 0a01c169f0ab0f91b26e77a3301fbfe4

--- a/pixi.toml
+++ b/pixi.toml
@@ -159,6 +159,7 @@ build = ">=1.2.2.post1, <2"
 
 [feature.build.dependencies]
 scikit-build-core = "*"
+auditwheel = "*"
 
 [feature.build.tasks.build-sdist]
 cmd = ["python", "-m", "build", ".", "--sdist", "--outdir", "dist"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -156,7 +156,6 @@ python = "3.13.*"
 # Dependencies and tasks for building distribution packages
 [feature.build.pypi-dependencies]
 build = ">=1.2.2.post1, <2"
-auditwheel-symbols = "*"
 
 [feature.build.dependencies]
 scikit-build-core = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -156,6 +156,7 @@ python = "3.13.*"
 # Dependencies and tasks for building distribution packages
 [feature.build.pypi-dependencies]
 build = ">=1.2.2.post1, <2"
+auditwheel-symbols = "*"
 
 [feature.build.dependencies]
 scikit-build-core = "*"


### PR DESCRIPTION
This pull request adds support for repairing Python wheels for Linux distributions using `auditwheel` during the build process, ensuring better compatibility and compliance with manylinux standards. It also updates the build dependencies to include `auditwheel`.

**Build process improvements:**

* Added a new job step in `.github/workflows/cd.yml` to run `auditwheel show` and `auditwheel repair` on built wheels for the `linux-intel` environment, replacing the original wheels with repaired ones and listing the results.

**Dependency updates:**

* Added `auditwheel` as a build dependency in `pixi.toml` to enable wheel auditing and repair functionality.