### PR TITLE
chore: Update versions and add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+## Citation metadata for the HPyX project
+## Adjust fields (e.g., doi, version, date-released) as official releases are made.
+
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "HPyX: Python Binding for the HPX C++ Library"
+version: 2025.8.28
+license: BSD-3-Clause
+type: software
+authors:
+  - family-names: "Setiawan"
+    given-names: "Landung"
+    orcid: "https://orcid.org/0000-0002-1624-2667"
+  - family-names: "Nag"
+    given-names: "Ayush"
+    orcid: "https://orcid.org/0009-0008-1790-597X"
+  - family-names: "Gordon"
+    given-names: "Madeline"
+    orcid: "https://orcid.org/0009-0003-6220-7218"
+  - given-names: Hartmut
+    family-names: Kaiser
+## Optional fields to fill in when available
+## doi: 10.5281/zenodo.xxxxxxx
+## date-released: 2025-08-28

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HPyX: Python Bindings for HPX C++ Parallelism Library
 
+[![DOI](https://zenodo.org/badge/966326660.svg)](https://zenodo.org/badge/latestdoi/966326660)
 <span><img src="https://img.shields.io/badge/SSEC-Project-purple?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAQAAABedl5ZAAAACXBIWXMAAAHKAAABygHMtnUxAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAMNJREFUGBltwcEqwwEcAOAfc1F2sNsOTqSlNUopSv5jW1YzHHYY/6YtLa1Jy4mbl3Bz8QIeyKM4fMaUxr4vZnEpjWnmLMSYCysxTcddhF25+EvJia5hhCudULAePyRalvUteXIfBgYxJufRuaKuprKsbDjVUrUj40FNQ11PTzEmrCmrevPhRcVQai8m1PRVvOPZgX2JttWYsGhD3atbHWcyUqX4oqDtJkJiJHUYv+R1JbaNHJmP/+Q1HLu2GbNoSm3Ft0+Y1YMdPSTSwQAAAABJRU5ErkJggg==&style=plastic" /><span>
 ![BSD License](https://badgen.net/badge/license/BSD-3-Clause/blue)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ channels = ["conda-forge"]
 description = "Python Binding for HPX C++ library"
 name = "hpyx"
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
-version = "0.1.0"
+version = "2025.8.28"
 
 # === Project Environments ===
 # Define various development environments with different feature combinations


### PR DESCRIPTION
This pull request introduces citation metadata for the HPyX project and updates project versioning to align with an upcoming release. It also adds a DOI badge for improved discoverability. The most important changes are grouped below:

Citation and metadata:

* Added a new `CITATION.cff` file with citation information for HPyX, including authors, version, license, and instructions for future updates.

Versioning and release preparation:

* Updated the project version in `pixi.toml` from `0.1.0` to `2025.8.28` to reflect the upcoming release.

Documentation and discoverability:

* Added a Zenodo DOI badge to the top of the `README.md` for easier citation and tracking of the project.