### PR TITLE
chore: add Claude Code commands and hpx-dev plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "hpyx-local",
+  "owner": {
+    "name": "Landung 'Don' Setiawan",
+    "email": "landungs@uw.edu",
+    "url": "https://github.com/lsetiawan"
+  },
+  "plugins": [
+    {
+      "name": "hpx-dev",
+      "source": "./plugins/hpx-dev",
+      "description": "Development toolkit for HPyX — HPX Python bindings."
+    }
+  ]
+}

--- a/.claude/commands/clean-branches.md
+++ b/.claude/commands/clean-branches.md
@@ -1,0 +1,52 @@
+Clean up local and remote git branches.
+
+## Arguments
+
+$ARGUMENTS — optional: "all", "stale", "merged", or a specific branch name. If
+omitted, prompt the user.
+
+## Instructions
+
+1. Run these commands in parallel to gather branch information:
+   - `git branch` (local branches)
+   - `git branch -r` (remote branches, exclude HEAD)
+   - `git branch --merged main` (branches merged into main)
+   - `git for-each-ref --sort=-committerdate --format='%(refname:short) %(committerdate:relative) %(upstream:track)' refs/heads/`
+     (local branches with age and tracking status)
+
+2. Categorize each branch (excluding `main` and `feedback-screenshots`):
+
+   | Category            | Definition                                                        |
+   | ------------------- | ----------------------------------------------------------------- |
+   | **Merged**          | Branch is in `git branch --merged main` output                    |
+   | **Stale**           | Last commit is older than 30 days                                 |
+   | **Orphaned remote** | Remote branch exists but no local branch tracks it                |
+   | **Orphaned local**  | Local branch exists but remote is gone (`[gone]` tracking status) |
+   | **Active**          | Has recent commits and is not merged                              |
+
+3. If `$ARGUMENTS` is empty or unclear:
+   - Display a summary table of all branches grouped by category with branch
+     name, last commit age, and local/remote status
+   - Ask the user which categories to clean: merged, stale, orphaned, or all
+   - Wait for the user's response before proceeding
+
+4. If `$ARGUMENTS` specifies a category or "all":
+   - Show the list of branches that will be deleted
+   - Ask for confirmation before proceeding
+
+5. Delete branches:
+   - Local branches: `git branch -d <name>` (safe delete, merged only) or
+     `git branch -D <name>` (if user confirms force delete for unmerged)
+   - Remote branches: `git push origin --delete <name>`
+   - Run `git fetch --prune` after remote deletions
+
+6. Confirm results: show what was deleted and what remains.
+
+## Rules
+
+- NEVER delete `main`, `master`, or `feedback-screenshots` branches
+- NEVER force-delete (`-D`) without explicit user confirmation
+- Always show what will be deleted before doing it
+- If a branch has unmerged commits, warn the user and ask before force-deleting
+- Run `git fetch --prune` at the end to clean up stale remote refs
+- If there are no branches to clean, say so and exit

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,58 @@
+Commit staged and unstaged changes to the current branch.
+
+## Instructions
+
+1. Run `git status` (never use `-uall`) and `git diff --stat` to see all
+   changes.
+2. Run `git log --oneline -5` to see the commit message style for this repo.
+3. Analyze ALL changes (staged + unstaged) and determine:
+   - The conventional commit type: `feat`, `fix`, `refactor`, `docs`, `chore`,
+     `style`, `test`, `perf`, `ci`, `build`
+   - An optional scope in parentheses based on what area changed (e.g.,
+     `marketing`, `platform`, `developer`, `billing`, `db`, `auth`, `worker`,
+     `ui`, `tokens`)
+   - A concise imperative description of WHY, not WHAT
+4. Do NOT commit files that likely contain secrets (`.env`, `.env.local`,
+   credentials, API keys). Warn if any are staged.
+5. Do NOT commit `.DS_Store` files.
+6. Stage relevant untracked files by name (never use `git add -A` or
+   `git add .`).
+7. Create the commit using this format:
+
+```
+git commit -m "$(cat <<'EOF'
+type(scope): short imperative description
+
+Optional body explaining the why, not the what.
+Multi-line is fine for complex changes.
+EOF
+)"
+```
+
+8. Run `git status` after to verify success.
+9. If a pre-commit hook fails, fix the issue and create a NEW commit (never
+   amend).
+
+## Conventional Commit Types
+
+| Type       | When to use                                             |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | New feature or capability                               |
+| `fix`      | Bug fix                                                 |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `docs`     | Documentation only                                      |
+| `chore`    | Maintenance, deps, config                               |
+| `style`    | Formatting, whitespace (not CSS)                        |
+| `test`     | Adding or updating tests                                |
+| `perf`     | Performance improvement                                 |
+| `ci`       | CI/CD changes                                           |
+| `build`    | Build system or tooling                                 |
+
+## Rules
+
+- Keep the first line under 72 characters
+- Use imperative mood ("add" not "added", "fix" not "fixed")
+- Scope is optional but preferred when changes are localized
+- Never skip hooks (`--no-verify`)
+- Never amend unless explicitly asked
+- NEVER add `Co-Authored-By` trailers or any AI attribution to commit messages

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,62 @@
+Create a GitHub issue for tracking work.
+
+## Arguments
+
+$ARGUMENTS — a description of the issue to create
+
+## Instructions
+
+1. Based on `$ARGUMENTS`, determine:
+   - **Type**: `feat`, `fix`, `refactor`, `docs`, `chore`, `perf`, `ci`,
+     `build`, `test`
+   - **Scope**: the area of the codebase affected (e.g., `marketing`,
+     `platform`, `developer`, `billing`, `db`, `auth`, `worker`, `ui`, `tokens`,
+     `infra`)
+   - **Title**: conventional commit format:
+     `type(scope): short imperative description`
+
+2. Draft a structured issue body with relevant sections:
+
+```bash
+gh issue create --title "type(scope): description" --body "$(cat <<'EOF'
+## Summary
+
+<1-2 sentences describing the problem or feature>
+
+## Requirements
+
+<bulleted list of specific requirements or acceptance criteria>
+- [ ] Requirement 1
+- [ ] Requirement 2
+
+## Context
+
+<any relevant context, links, or background — omit if not needed>
+
+## Implementation Notes
+
+<optional technical direction or constraints — omit if not needed>
+EOF
+)"
+```
+
+3. Return the issue URL and number to the user.
+
+## Title Convention
+
+| Type              | Example                                                             |
+| ----------------- | ------------------------------------------------------------------- |
+| `feat(marketing)` | `feat(marketing): add testimonial carousel to landing page`         |
+| `fix(auth)`       | `fix(auth): resolve PKCE exchange failure on second localhost port` |
+| `refactor(db)`    | `refactor(db): normalize ingredient tables to reduce duplication`   |
+| `docs(guides)`    | `docs(guides): add Stripe webhook deployment checklist`             |
+| `chore(deps)`     | `chore(deps): upgrade React to 19.3`                                |
+
+## Rules
+
+- Title must use conventional commit format: `type(scope): description`
+- Keep title under 70 characters
+- Use imperative mood ("add" not "adds", "fix" not "fixes")
+- Requirements section should have checkboxes for trackable items
+- Omit sections that aren't relevant (don't pad with empty sections)
+- If `$ARGUMENTS` is vague, ask clarifying questions before creating

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,58 @@
+Create a pull request for the current branch.
+
+## Instructions
+
+1. Run these commands in parallel to understand the current state:
+   - `git status` (never use `-uall`)
+   - `git diff --stat` (check for uncommitted changes)
+   - `git branch --show-current` (current branch)
+   - `git log --oneline main..HEAD` (all commits being PR'd)
+   - `git diff main...HEAD --stat` (full diff summary against main)
+
+2. If there are uncommitted changes, ask whether to commit first.
+
+3. If the branch hasn't been pushed, push with `git push -u origin <branch>`.
+
+4. Analyze ALL commits in the branch (not just the latest) to draft:
+   - **Title**: Use conventional commit format: `type(scope): short description`
+     (under 70 chars)
+   - **Body**: Structured summary with test plan
+
+5. Create the PR:
+
+```bash
+gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points covering what changed and why>
+
+## Changes
+<bulleted list of specific changes, grouped by area if needed>
+
+## Test plan
+- [ ] <specific testable checklist items>
+EOF
+)"
+```
+
+6. If there's a related issue, add `Closes #N` in the body.
+7. Return the PR URL to the user.
+
+## Title Convention
+
+Use the same conventional commit types as /commit:
+
+- `feat(scope):` for new features
+- `fix(scope):` for bug fixes
+- `refactor(scope):` for restructuring
+- `docs(scope):` for documentation
+- `chore(scope):` for maintenance
+
+## Rules
+
+- Keep title under 70 characters
+- Always include a test plan with specific checkboxes
+- Never create a PR from `main` to `main`
+- If the branch name contains a hint (e.g., `feat/`, `fix/`), use that as the
+  commit type
+- NEVER add `Co-Authored-By` trailers, AI attribution, or "Generated with" lines
+  to PR titles, bodies, or commit messages

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -1,0 +1,107 @@
+Write comprehensive documentation for recent work in this session.
+
+Arguments: $ARGUMENTS (optional — topic, section, or "all" to regenerate
+broadly)
+
+## Instructions
+
+1. **Gather context** — Run these in parallel to understand what changed:
+   - `git log --oneline -20` (recent commits)
+   - `git diff main...HEAD --stat` (if on a feature branch)
+   - `git log --oneline --since="8 hours ago"` (today's work)
+   - Review any open plans in `docs/plans/`
+   - Read `docs/index.md` and `mkdocs.yml` for existing structure
+
+2. **Determine scope** — Based on the argument and recent changes, decide which
+   docs need writing or updating:
+   - If argument is a specific topic (e.g., "queues", "auth", "notifications"),
+     focus there
+   - If argument is a section (e.g., "architecture", "database", "guides"),
+     update that section
+   - If argument is "all" or empty, document everything from the current session
+   - Always check existing docs first — update rather than duplicate
+
+3. **Write documentation** covering these categories as relevant:
+
+   ### Technical Details
+   - What was built, changed, or fixed
+   - API contracts, database schema changes, new RPC functions
+   - Configuration changes, environment variables, dependencies added
+   - Code patterns introduced or modified
+
+   ### Technical Architecture
+   - System design and component relationships
+   - Data flow diagrams (use Mermaid syntax)
+   - Integration points between services (workers, platform, database)
+   - Infrastructure decisions (Cloudflare, Neon, WorkOS, Stripe, etc.)
+
+   ### Session Learnings
+   - Decisions made and their rationale (ADR-style: Decision / Why / Result)
+   - Technical issues encountered and how they were resolved
+   - Trade-offs considered and which path was chosen
+   - Gotchas, edge cases, or surprising behavior discovered
+   - Things that didn't work and why
+
+4. **Place documentation correctly:**
+   - New architecture docs → `docs/architecture/`
+   - Database changes → `docs/database/`
+   - Frontend changes → `docs/frontend/`
+   - How-to content → `docs/guides/`
+   - Implementation plans → `docs/plans/` (named `YYYY-MM-DD-topic.md`)
+   - Session learnings → `docs/guides/architecture-decisions.md` (append new
+     entries at top of relevant section)
+   - Script documentation → `docs/scripts/`
+
+5. **Update mkdocs.yml nav** — If you created a new file, add it to the `nav:`
+   section in `mkdocs.yml` under the correct heading. Match existing indentation
+   and naming style.
+
+6. **Update docs/index.md** — If the new doc is significant, add a link in the
+   Documentation section of `docs/index.md` with a one-line description.
+
+7. **Verify** — Run `pixi run docs-build` to confirm MkDocs builds without
+   errors.
+
+8. **Report** — Show the user:
+   - Files created or updated (with paths)
+   - New nav entries added
+   - Build status (pass/fail)
+
+## Documentation Style
+
+- Use MkDocs Material features: admonitions (`!!! note`, `!!! warning`,
+  `!!! tip`), tabs, Mermaid diagrams, code blocks with language tags
+- Start every doc with a level-1 heading and a 1-2 sentence summary
+- Use tables for structured data (configs, env vars, field mappings)
+- Keep headings hierarchical (h1 → h2 → h3, never skip levels)
+- Use imperative voice for guides ("Run the migration", not "You should run the
+  migration")
+- Architecture decisions follow the pattern:
+
+```markdown
+### YYYY-MM-DD: Decision Title (Status)
+
+- **Decision:** What was decided
+- **Why:** The reasoning and constraints
+- **Result:** What was implemented and any notable outcomes
+```
+
+## Mermaid Diagram Conventions
+
+- Use `graph TD` for top-down architecture diagrams
+- Use `sequenceDiagram` for request/response flows
+- Use `erDiagram` for database relationships
+- Keep diagrams focused — split complex systems into multiple diagrams
+- Label edges with the protocol or mechanism (e.g., `-->|JWT|`, `-->|REST|`,
+  `-->|Queue|`)
+
+## Rules
+
+- Never delete existing documentation — update or extend it
+- Always read existing docs before writing to avoid duplication
+- Every new doc must appear in `mkdocs.yml` nav
+- Date-stamp architecture decisions and plans
+- Use relative links between docs (e.g., `../guides/getting-started.md`)
+- Build must pass before considering the task done
+- If `pixi run docs-build` fails, fix the issue (usually a nav mismatch or
+  broken link)

--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -1,0 +1,51 @@
+Merge a pull request and clean up branches.
+
+## Arguments
+
+$ARGUMENTS — PR number or URL (optional, defaults to current branch's PR)
+
+## Instructions
+
+1. Determine the PR:
+   - If `$ARGUMENTS` is provided, use it as the PR number or URL
+   - If not, find the PR for the current branch:
+     `gh pr view --json number,title,state,headRefName`
+
+2. Check PR status:
+   - `gh pr view <number> --json state,mergeable,mergeStateStatus,statusCheckRollup,title,headRefName`
+   - If checks are failing, warn the user and ask whether to proceed
+   - If there are merge conflicts, tell the user and stop
+
+3. Check for local uncommitted changes:
+   - `git status`
+   - If there are unstaged changes, stash them before proceeding: `git stash`
+
+4. Merge the PR:
+
+   ```bash
+   gh pr merge <number> --squash --delete-branch
+   ```
+
+   Use `--squash` by default (consistent with this repo's history).
+
+5. Clean up locally:
+   - Switch to main if not already: `git checkout main`
+   - Pull the merged changes: `git pull origin main`
+   - Prune stale remote refs: `git fetch --prune`
+   - Delete the local branch if it still exists: `git branch -d <branch-name>`
+   - If changes were stashed, restore them: `git stash pop`
+
+6. Verify cleanup:
+   - `git branch -a | grep <branch-name>` to confirm branch is gone everywhere
+
+7. Confirm: "PR #N merged into main. Branch `<name>` deleted locally and
+   remotely."
+
+## Rules
+
+- Default merge strategy is `--squash` (produces clean linear history)
+- If user asks for a merge commit, use `--merge` instead
+- If user asks for rebase, use `--rebase` instead
+- NEVER force-delete branches (`-D`), use `-d` which is safe
+- Always restore stashed changes after merge
+- If the merge fails, do NOT retry destructively — report the error

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,25 @@
+Push the current branch to the remote repository.
+
+## Instructions
+
+1. Run `git status` to check:
+   - Current branch name
+   - Whether there are uncommitted changes (warn the user if so)
+   - Whether the branch tracks a remote
+2. Run `git log --oneline origin/$(git branch --show-current)..HEAD 2>/dev/null`
+   to see unpushed commits. If the remote branch doesn't exist yet, show all
+   commits since diverging from `main`.
+3. Show the user what will be pushed (branch name + commit list).
+4. Push:
+   - If the branch has no upstream yet: `git push -u origin <branch-name>`
+   - If it already tracks a remote: `git push`
+5. Confirm success.
+
+## Rules
+
+- NEVER force push (`--force`, `-f`) unless the user explicitly asks
+- NEVER force push to `main` or `master` — warn the user and refuse
+- If there are uncommitted changes, ask whether to commit first (using /commit
+  conventions) or push what's already committed
+- If push is rejected due to remote changes, suggest `git pull --rebase` and ask
+  before proceeding

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,122 @@
+Create a versioned release with changelog, tag, GitHub release, and plugin zip
+assets.
+
+## Arguments
+
+$ARGUMENTS — version bump type: `patch`, `minor`, or `major` (optional, defaults
+to analyzing changes)
+
+## Instructions
+
+1. Determine the version bump:
+   - If `$ARGUMENTS` specifies `patch`, `minor`, or `major`, use that
+   - If not specified, analyze commits since the last tag to determine:
+     - `major`: breaking changes (commits with `!` or `BREAKING CHANGE`)
+     - `minor`: new features (`feat:` commits)
+     - `patch`: fixes, refactors, docs, chores only
+
+2. Get the current version:
+   - Check `git tag --sort=-v:refname | head -1` for the latest tag
+   - If no tags exist, start at `v0.1.0`
+
+3. Calculate the new version following semver.
+
+4. Verify readiness:
+   - `git status` — must be on `main` with no uncommitted changes
+   - `git pull origin main` — must be up to date
+   - Warn and stop if not on `main` or if there are uncommitted changes
+
+5. Read `CHANGELOG.md` and check that the `[Unreleased]` section has content.
+
+6. Update `CHANGELOG.md`:
+   - Rename `[Unreleased]` to `[X.Y.Z] -- YYYY-MM-DD` (today's date)
+   - Add a new empty `[Unreleased]` section above it
+
+7. Commit the changelog update:
+
+   ```bash
+   git add CHANGELOG.md
+   git commit -m "$(cat <<'EOF'
+   chore(release): prepare vX.Y.Z
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+8. Create the git tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   ```
+
+9. Push the commit and tag:
+
+   ```bash
+   git push origin main --follow-tags
+   ```
+
+10. Build plugin zip assets:
+    - For each directory in `plugins/`, create a zip archive
+    - **Zip naming convention:**
+      - Default: `plugin_name_MM_DD_YYYY.zip` (snake_case plugin name + date)
+      - If a release already exists for today (check `gh release list`), append
+        a sequence suffix: `plugin_name_MM_DD_YYYY_2.zip`, `_3.zip`, etc.
+    - Example: `recipe_workshop_03_30_2026.zip`, or
+      `recipe_workshop_03_30_2026_2.zip` for a second release that day
+    - Create zips from within the `plugins/` directory so the zip root is the
+      plugin folder itself:
+      ```bash
+      cd plugins && zip -r ../plugin_name_MM_DD_YYYY.zip plugin-dir-name/ -x "*.DS_Store" "*__pycache__/*" "*.pyc" && cd ..
+      ```
+    - Exclude unnecessary files from zip: `.DS_Store`, `__pycache__`, `*.pyc`
+
+11. Create a GitHub release with plugin zips as assets:
+
+    ```bash
+    gh release create vX.Y.Z --title "vX.Y.Z" \
+      --notes "$(cat <<'EOF'
+    ## What's Changed
+
+    <extract the relevant section from CHANGELOG.md>
+
+    ## Plugin Assets
+
+    <list each plugin zip with name and description>
+
+    **Full Changelog**: https://github.com/cdcore09/recipe-workshop/compare/vPREVIOUS...vX.Y.Z
+    EOF
+    )" \
+      plugin_name_MM_DD_YYYY.zip
+    ```
+
+12. Clean up zip files from the repo root after successful upload.
+
+13. Confirm: "Released vX.Y.Z — <release URL>"
+
+## Version Guidelines
+
+| Bump            | When                               | Example             |
+| --------------- | ---------------------------------- | ------------------- |
+| `patch` (0.1.X) | Bug fixes, docs, chores, refactors | `v0.1.1` → `v0.1.2` |
+| `minor` (0.X.0) | New features, non-breaking changes | `v0.1.2` → `v0.2.0` |
+| `major` (X.0.0) | Breaking changes, major rewrites   | `v0.2.0` → `v1.0.0` |
+
+## Zip Naming Rules
+
+- Plugin directory name is converted to snake_case: `recipe-workshop` →
+  `recipe_workshop`
+- Date format is `MM_DD_YYYY`
+- Sequence suffix only added when multiple releases occur on the same day
+- Sequence starts at `_2` (first release of the day has no suffix)
+
+## Rules
+
+- Must be on `main` branch with no uncommitted changes
+- Must have content in `[Unreleased]` section of CHANGELOG.md
+- Never create a release from a feature branch
+- Tag format is always `vX.Y.Z` (with `v` prefix)
+- Ask for confirmation before pushing the tag and creating the release
+- If CHANGELOG.md doesn't exist or has no `[Unreleased]` section, warn and ask
+  how to proceed
+- Never commit generated zip files — they are upload artifacts only

--- a/plugins/hpx-dev/.claude-plugin/plugin.json
+++ b/plugins/hpx-dev/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "hpx-dev",
+  "version": "0.1.0",
+  "description": "Development toolkit for HPyX — HPX Python bindings. Provides deep HPX knowledge, binding patterns, build system guidance, benchmarking, and code review for contributors.",
+  "author": {
+    "name": "Landung 'Don' Setiawan",
+    "email": "landungs@uw.edu",
+    "url": "https://github.com/lsetiawan"
+  },
+  "homepage": "https://github.com/uw-ssec/HPyX",
+  "repository": "https://github.com/uw-ssec/HPyX",
+  "license": "BSD-3-Clause",
+  "keywords": ["hpx", "hpyx", "nanobind", "python-bindings", "parallel-computing", "free-threading", "c++", "hpc", "scientific-computing", "performance", "code-review"]
+}

--- a/plugins/hpx-dev/README.md
+++ b/plugins/hpx-dev/README.md
@@ -1,0 +1,86 @@
+# hpx-dev
+
+Claude Code development toolkit for [HPyX](https://github.com/uw-ssec/HPyX) — HPX Python bindings built with Nanobind. Provides deep HPX knowledge, binding patterns, build system guidance, benchmarking, and code review for contributors.
+
+- **Version:** 0.1.0
+- **License:** BSD-3-Clause
+- **Repository:** https://github.com/uw-ssec/HPyX
+
+## What's Included
+
+This plugin ships three subagents and six auto-activating skills. There are no slash commands, hooks, or MCP servers.
+
+### Agents (`agents/`)
+
+| Agent | When to use |
+|---|---|
+| `hpx-api-explorer` | Search `vendor/hpx/` to discover HPX C++ APIs and signatures suitable for Python binding. |
+| `binding-reviewer` | Review C++/Python binding code (`src/*.cpp`, `src/hpyx/`) for GIL safety, type correctness, and pattern adherence. |
+| `benchmark-engineer` | Write, run, and analyze `pytest-benchmark` performance tests (HPX vs NumPy, thread scaling, regression checks). |
+
+Invoke via the `Agent` tool — agents are selected automatically based on task context, or can be requested by name.
+
+### Skills (`skills/`)
+
+Skills auto-activate when their trigger phrases appear in conversation.
+
+| Skill | Triggers on topics like |
+|---|---|
+| `hpx-architecture` | HPX components, parallel algorithms, futures, AGAS, execution policies, `vendor/hpx` |
+| `nanobind-patterns` | Writing Nanobind bindings, type conversions, ndarray bindings, `src/*.cpp` patterns |
+| `add-binding` | Scaffolding a new end-to-end HPX binding (C++ + header + Python wrapper + tests + CMake) |
+| `gil-management` | Python 3.13 free-threading, `gil_scoped_acquire/release`, thread safety, callback segfaults |
+| `build-system` | CMake, scikit-build-core, pixi, `nanobind_add_module`, build/link/RPATH errors |
+| `benchmarking` | `pytest-benchmark`, `benchmarks/` directory, thread scaling, HPX vs Python/NumPy comparisons |
+
+Three of the skills (`hpx-architecture`, `nanobind-patterns`, `benchmarking`) ship reference documents in a `references/` subdirectory for deeper context.
+
+## Installation
+
+From the HPyX repository root, this plugin lives at `plugins/hpx-dev/`. With Claude Code's plugin support, point at the directory:
+
+```bash
+# From the Claude Code UI or settings, add a local plugin source pointing at:
+# /absolute/path/to/HPyX/plugins/hpx-dev
+```
+
+Or reference it through a marketplace / plugin registry entry that resolves to this directory.
+
+Once the plugin is enabled, the agents and skills register automatically — no restart required beyond a new Claude Code session.
+
+## Directory Layout
+
+```
+hpx-dev/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   ├── hpx-api-explorer.md
+│   ├── binding-reviewer.md
+│   └── benchmark-engineer.md
+└── skills/
+    ├── hpx-architecture/
+    │   ├── SKILL.md
+    │   └── references/
+    ├── nanobind-patterns/
+    │   ├── SKILL.md
+    │   └── references/
+    ├── add-binding/SKILL.md
+    ├── gil-management/SKILL.md
+    ├── build-system/SKILL.md
+    └── benchmarking/
+        ├── SKILL.md
+        └── references/
+```
+
+## Contributing
+
+Contributions follow the HPyX project conventions. When modifying plugin components:
+
+- Keep agent and skill frontmatter valid (see existing files for the expected shape).
+- Use kebab-case for directory and file names.
+- Run the `plugin-dev:plugin-validator` agent after changes to catch regressions.
+
+## License
+
+BSD-3-Clause — see the root HPyX repository for the full license text.

--- a/plugins/hpx-dev/agents/benchmark-engineer.md
+++ b/plugins/hpx-dev/agents/benchmark-engineer.md
@@ -1,6 +1,7 @@
 ---
 name: benchmark-engineer
-description: Use this agent to write, run, and analyze performance benchmarks for HPyX bindings. Trigger when the user wants to benchmark a new binding, compare HPX vs Python/NumPy performance, measure thread scaling, or analyze performance results. Examples:
+description: |
+  Use this agent to write, run, and analyze performance benchmarks for HPyX bindings. Trigger when the user wants to benchmark a new binding, compare HPX vs Python/NumPy performance, measure thread scaling, or analyze performance results. Examples:
 
   <example>
   Context: User added a new binding and wants to benchmark it

--- a/plugins/hpx-dev/agents/benchmark-engineer.md
+++ b/plugins/hpx-dev/agents/benchmark-engineer.md
@@ -1,0 +1,125 @@
+---
+name: benchmark-engineer
+description: Use this agent to write, run, and analyze performance benchmarks for HPyX bindings. Trigger when the user wants to benchmark a new binding, compare HPX vs Python/NumPy performance, measure thread scaling, or analyze performance results. Examples:
+
+  <example>
+  Context: User added a new binding and wants to benchmark it
+  user: "Write benchmarks for the new reduce binding"
+  assistant: "I'll use the benchmark-engineer agent to create and run benchmarks."
+  <commentary>
+  New binding needs performance characterization. Create benchmarks following HPyX patterns.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to compare performance
+  user: "How does our dot1d compare to numpy's dot product?"
+  assistant: "I'll run the benchmarks and analyze the comparison."
+  <commentary>
+  User wants performance comparison data. Run existing benchmarks and analyze results.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to understand scaling behavior
+  user: "How does the for_loop scale with thread count?"
+  assistant: "I'll create and run thread scaling benchmarks."
+  <commentary>
+  User wants scaling analysis. Create parametrized benchmarks with different thread counts.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User notices performance regression
+  user: "The async submit seems slower after the recent changes"
+  assistant: "I'll benchmark and profile to identify the regression."
+  <commentary>
+  Performance regression investigation. Run benchmarks and compare to baseline.
+  </commentary>
+  </example>
+
+model: inherit
+color: green
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+You are a performance engineer specializing in Python/C++ binding benchmarks for the HPyX project. You write, run, and analyze benchmarks that measure HPyX binding performance.
+
+**Your Core Responsibilities:**
+
+1. Write benchmarks following HPyX's pytest-benchmark patterns
+2. Run benchmarks using the project's pixi infrastructure
+3. Analyze results and identify performance characteristics
+4. Compare HPX bindings against NumPy and pure Python baselines
+5. Measure thread scaling efficiency and binding overhead
+
+**Benchmark Writing Process:**
+
+1. Read existing benchmarks in `benchmarks/` for pattern reference:
+   - `benchmarks/test_bench_hpx_linalg.py` — HPX vs NumPy comparison pattern
+   - `benchmarks/test_bench_for_loop.py` — Thread scaling and policy comparison pattern
+2. Create benchmark file following naming convention: `benchmarks/test_bench_<feature>.py`
+3. Include these standard comparisons:
+   - HPX multi-thread vs NumPy (default threads)
+   - HPX single-thread vs NumPy single-thread (controlled comparison)
+   - HPX vs pure Python (shows binding value)
+   - Thread scaling (1, 2, 4, N threads)
+4. Use `@pytest.mark.parametrize` for data sizes covering small (overhead-visible), medium (throughput), and large (memory-bandwidth) ranges
+
+**Benchmark Execution:**
+
+Run benchmarks with:
+```bash
+pixi run -e benchmark-py313t run-benchmark keyword_expression="<feature_name>"
+```
+
+Or for all benchmarks:
+```bash
+pixi run benchmark
+```
+
+**Analysis Guidelines:**
+
+When analyzing results, consider:
+- **Binding overhead**: Small constant cost of crossing Python/C++ boundary
+- **Thread scaling**: Expect near-linear scaling for compute-bound work up to core count
+- **Memory bandwidth**: Large array operations may be memory-bound, not compute-bound
+- **GIL contention**: Operations with Python callbacks may show limited parallel speedup
+- **Runtime startup**: HPXRuntime initialization cost should be excluded from operation benchmarks
+
+**Output Format:**
+
+For benchmark results, provide:
+
+```
+## Benchmark Results: <feature>
+
+### Configuration
+- Python: 3.13 (free-threading)
+- HPX threads: [auto/N]
+- Data sizes: [sizes tested]
+
+### Results Summary
+| Implementation | Size | Mean (ms) | StdDev | Ops/sec |
+|---|---|---|---|---|
+| HPX (par) | 10M | ... | ... | ... |
+| NumPy | 10M | ... | ... | ... |
+| Python | 10M | ... | ... | ... |
+
+### Analysis
+- Thread scaling efficiency: [X]
+- Binding overhead: [Y ms]
+- Crossover point: [size where HPX beats NumPy]
+- Bottleneck: [compute/memory/GIL]
+
+### Recommendations
+- [Optimization suggestions if applicable]
+```
+
+**Key Patterns from Existing Benchmarks:**
+
+- Use `np.random.default_rng()` for reproducible random data
+- Create data OUTSIDE the benchmarked function
+- Place `HPXRuntime()` context based on what to measure
+- Use `threadpool_limits(limits=1)` from threadpoolctl for fair single-thread NumPy comparison
+- Follow naming: `test_bench_{hpx|np|python}_{operation}[_{variant}]`

--- a/plugins/hpx-dev/agents/binding-reviewer.md
+++ b/plugins/hpx-dev/agents/binding-reviewer.md
@@ -1,0 +1,107 @@
+---
+name: binding-reviewer
+description: Use this agent to review C++/Python binding code for correctness, GIL safety, and adherence to HPyX patterns. Trigger proactively after writing or modifying C++ binding code in src/*.cpp or Python wrappers in src/hpyx/. Examples:
+
+  <example>
+  Context: User just wrote a new Nanobind binding in src/
+  user: "I've added a new reduce binding in src/reduce.cpp"
+  assistant: "Let me review the binding for correctness."
+  <commentary>
+  New binding code was written. Proactively review for GIL safety, type correctness, and pattern adherence.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User modified existing binding code
+  user: "I changed the for_loop binding to support par_unseq policy"
+  assistant: "I'll review the changes for thread safety and correctness."
+  <commentary>
+  Existing binding was modified. Review for regressions and correct GIL handling.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User asks for explicit review
+  user: "Review my HPX binding code"
+  assistant: "I'll use the binding-reviewer agent to analyze the code."
+  <commentary>
+  Explicit review request for binding code.
+  </commentary>
+  </example>
+
+model: inherit
+color: yellow
+tools: Read, Grep, Glob
+---
+
+You are an expert C++/Python binding code reviewer specializing in Nanobind + HPX integration. Your role is to review HPyX binding code for correctness, safety, and adherence to project patterns.
+
+**Your Core Responsibilities:**
+
+1. Verify GIL management correctness (acquire before Python calls, release during blocking C++)
+2. Check Nanobind type mappings and conversions
+3. Validate HPX API usage (correct headers, execution policies, future handling)
+4. Ensure consistency with existing HPyX patterns in src/
+5. Verify the Python wrapper layer follows project conventions
+
+**Review Process:**
+
+1. Read the binding code under review
+2. Read existing reference files for pattern comparison:
+   - `src/bind.cpp` — Module registration pattern
+   - `src/futures.cpp` — Python callback pattern with GIL
+   - `src/algorithms.cpp` — Pure C++ operation pattern
+   - `src/init_hpx.cpp` — Runtime management pattern
+3. Read the corresponding Python wrapper if it exists
+4. Check `CMakeLists.txt` for correct source file registration
+5. Analyze for issues
+
+**Review Checklist:**
+
+GIL Safety:
+- Every lambda calling `nb::callable` or accessing `nb::object` has `nb::gil_scoped_acquire`
+- Long-running pure C++ operations use `nb::gil_scoped_release` when called from Python context
+- No GIL held during blocking waits on futures that may need the GIL
+- Deferred futures that call Python: verify GIL is acquired in the deferred lambda
+
+Type Safety:
+- `nb::ndarray` uses correct template parameters (numpy, dtype, c_contig)
+- Array size validation before pointer access
+- `std::move` used for move-only types like `hpx::future`
+- Correct use of `nb::arg()` annotations
+
+HPX Correctness:
+- Correct HPX headers included (specific headers, not catch-all `<hpx/hpx.hpp>`)
+- Execution policies used correctly
+- Future chains preserve move semantics
+- Runtime assumed to be initialized (no redundant init checks)
+
+Pattern Adherence:
+- Namespace matches filename convention
+- Header/source file pair exists
+- Registered in `NB_MODULE(_core, m)` block
+- `CMakeLists.txt` updated with new source files
+- Python wrapper exists with type hints and docstrings
+
+**Output Format:**
+
+Provide a structured review:
+
+```
+## Binding Review: <feature_name>
+
+### GIL Safety
+- [PASS/ISSUE] Description
+
+### Type Safety
+- [PASS/ISSUE] Description
+
+### HPX Correctness
+- [PASS/ISSUE] Description
+
+### Pattern Adherence
+- [PASS/ISSUE] Description
+
+### Summary
+Overall assessment and recommended fixes.
+```

--- a/plugins/hpx-dev/agents/binding-reviewer.md
+++ b/plugins/hpx-dev/agents/binding-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: binding-reviewer
-description: Use this agent to review C++/Python binding code for correctness, GIL safety, and adherence to HPyX patterns. Trigger proactively after writing or modifying C++ binding code in src/*.cpp or Python wrappers in src/hpyx/. Examples:
+description: |
+  Use this agent to review C++/Python binding code for correctness, GIL safety, and adherence to HPyX patterns. Trigger proactively after writing or modifying C++ binding code in src/*.cpp or Python wrappers in src/hpyx/. Examples:
 
   <example>
   Context: User just wrote a new Nanobind binding in src/

--- a/plugins/hpx-dev/agents/hpx-api-explorer.md
+++ b/plugins/hpx-dev/agents/hpx-api-explorer.md
@@ -1,0 +1,93 @@
+---
+name: hpx-api-explorer
+description: Use this agent to explore HPX C++ source code and find APIs suitable for Python binding. Trigger when the user wants to discover what HPX features are available, understand an HPX API's signature, or research how to wrap a specific HPX component. Examples:
+
+  <example>
+  Context: User wants to find HPX APIs to wrap
+  user: "What parallel algorithms does HPX provide that we haven't wrapped yet?"
+  assistant: "I'll use the hpx-api-explorer agent to search the HPX source."
+  <commentary>
+  User needs to discover unwrapped HPX APIs. Explorer searches vendor/hpx/ source.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to understand a specific HPX API
+  user: "How does hpx::when_all work? What's its signature?"
+  assistant: "I'll explore the HPX source to find the when_all API details."
+  <commentary>
+  User needs specific API information from the HPX C++ source.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User is planning what to bind next
+  user: "What HPX features would be useful for distributed computing in Python?"
+  assistant: "I'll explore HPX's distributed computing components."
+  <commentary>
+  User is researching HPX features for future binding work.
+  </commentary>
+  </example>
+
+model: inherit
+color: cyan
+tools: Read, Grep, Glob
+---
+
+You are an HPX C++ library expert specializing in exploring the HPX source code to find and document APIs suitable for Python binding.
+
+**Your Core Responsibilities:**
+
+1. Search `vendor/hpx/` source for C++ APIs matching user queries
+2. Document API signatures, template parameters, and usage patterns
+3. Assess binding feasibility (GIL implications, type mapping complexity)
+4. Compare against already-wrapped APIs in `src/` to avoid duplication
+5. Provide concrete recommendations for new bindings
+
+**Exploration Process:**
+
+1. Understand what the user is looking for
+2. Search HPX source directories:
+   - `vendor/hpx/libs/core/algorithms/` — Parallel algorithms
+   - `vendor/hpx/libs/core/futures/` — Future types and combinators
+   - `vendor/hpx/libs/core/synchronization/` — Latch, barrier, mutex
+   - `vendor/hpx/libs/core/execution/` — Execution policies and executors
+   - `vendor/hpx/libs/full/distributed/` — Distributed computing
+   - `vendor/hpx/libs/core/performance_counters/` — Performance monitoring
+3. Find the relevant header files and read API signatures
+4. Check `src/bind.cpp` and `src/*.cpp` for already-wrapped APIs
+5. Assess binding complexity and provide recommendations
+
+**Search Strategy:**
+
+- Start with header files (`*.hpp`) in `vendor/hpx/libs/`
+- Look for public API declarations (not internal implementation details)
+- Focus on functions/classes in the `hpx::` namespace
+- Check for execution policy overloads (seq, par, par_unseq)
+- Note template parameters and their constraints
+
+**Output Format:**
+
+For each discovered API:
+
+```
+## hpx::<function_name>
+
+**Header:** `<hpx/header.hpp>`
+**Location:** `vendor/hpx/libs/.../include/...`
+
+**Signature:**
+\`\`\`cpp
+template <typename ExPolicy, typename ...Args>
+ReturnType function_name(ExPolicy&& policy, Args&&... args);
+\`\`\`
+
+**Python Mapping:**
+- Input types: [C++ → Python mappings]
+- Return type: [C++ → Python mapping]
+- GIL: [acquire needed? release recommended?]
+
+**Binding Complexity:** [Low/Medium/High]
+**Already Wrapped:** [Yes/No]
+**Recommendation:** [Brief assessment]
+```

--- a/plugins/hpx-dev/agents/hpx-api-explorer.md
+++ b/plugins/hpx-dev/agents/hpx-api-explorer.md
@@ -1,6 +1,7 @@
 ---
 name: hpx-api-explorer
-description: Use this agent to explore HPX C++ source code and find APIs suitable for Python binding. Trigger when the user wants to discover what HPX features are available, understand an HPX API's signature, or research how to wrap a specific HPX component. Examples:
+description: |
+  Use this agent to explore HPX C++ source code and find APIs suitable for Python binding. Trigger when the user wants to discover what HPX features are available, understand an HPX API's signature, or research how to wrap a specific HPX component. Examples:
 
   <example>
   Context: User wants to find HPX APIs to wrap

--- a/plugins/hpx-dev/skills/add-binding/SKILL.md
+++ b/plugins/hpx-dev/skills/add-binding/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: add-binding
+description: Generates the complete scaffolding (C++ source, header, `bind.cpp` registration, CMake update, Python wrapper package, tests, and optional benchmarks) for a new HPX algorithm binding in HPyX. Use when the user asks to "add a new binding", "scaffold a binding", "create an HPX wrapper", "add hpx::for_each binding", "add hpx::reduce binding", "wrap a new HPX algorithm", "add a new HPX feature to HPyX", or provides a specific HPX feature name and wants end-to-end scaffolding.
+---
+
+# Add HPX Binding Scaffold
+
+## Workflow
+
+### Step 1: Identify the HPX Feature
+
+Determine which HPX C++ API to wrap. If the user provided a feature name, look it up in the HPX source:
+
+```
+vendor/hpx/libs/core/algorithms/  — Parallel algorithms (for_each, reduce, sort, etc.)
+vendor/hpx/libs/core/futures/     — Future combinators (when_all, when_any)
+vendor/hpx/libs/core/synchronization/ — Synchronization primitives (latch, barrier)
+```
+
+Search for the HPX header and understand the C++ API signature, template parameters, and execution policy support.
+
+### Step 2: Plan the Binding
+
+Checklist:
+- Input/output types and their Python equivalents
+- GIL acquisition needed (Python callbacks)
+- Which execution policies to expose (seq/par/par_unseq)
+- Python API name (snake_case)
+
+### Step 3: Create C++ Source
+
+Create `src/<feature_name>.cpp` with:
+
+```cpp
+#include <nanobind/nanobind.h>
+// Include appropriate HPX and Nanobind headers
+#include <hpx/algorithm.hpp>
+
+namespace nb = nanobind;
+
+namespace <feature_name> {
+
+// Implementation following HPyX patterns:
+// - Pure C++ operations: no GIL management needed
+// - Python callbacks: use nb::gil_scoped_acquire
+// - Return futures: use hpx::launch::deferred pattern
+
+} // namespace <feature_name>
+```
+
+Create `src/<feature_name>.hpp` with declarations.
+
+### Step 4: Register in bind.cpp
+
+Add to `src/bind.cpp`:
+1. `#include "<feature_name>.hpp"` at the top
+2. `m.def(...)` calls inside `NB_MODULE(_core, m)` block
+
+### Step 5: Update CMakeLists.txt
+
+Add `src/<feature_name>.cpp` to the `nanobind_add_module()` call. If the feature requires additional HPX components, add them to `target_link_libraries`.
+
+**Validation checkpoint**: run `pixi run build` and verify `_core.so` compiles before proceeding to the Python wrapper.
+
+### Step 6: Create Python Wrapper
+
+Create the Python package:
+
+```
+src/hpyx/<feature_name>/
+├── __init__.py          # Re-exports the public API
+└── _<feature_name>.py   # Implementation with type hints and docstrings
+```
+
+The Python wrapper should:
+- Import from `hpyx._core`
+- Add type hints and NumPy-style docstrings
+- Validate inputs (raise clear Python exceptions)
+- Provide sensible defaults
+- Raise `NotImplementedError` for unimplemented execution policies
+
+### Step 7: Export from Package
+
+Update `src/hpyx/__init__.py` to import and export the new module.
+
+### Step 8: Create Tests
+
+Create `tests/test_<feature_name>.py` with:
+- Basic functionality tests
+- Different input types (scalars, lists, numpy arrays)
+- Error handling tests (invalid inputs, edge cases)
+- Execution policy tests (seq, par if supported)
+- NumPy integration tests if applicable
+
+**Validation checkpoint**: run `pixi run test tests/test_<feature_name>.py` and confirm all tests pass before committing.
+
+### Step 9: Create Benchmarks (Optional)
+
+Create `benchmarks/test_bench_<feature_name>.py` with:
+- HPX vs NumPy comparison (if applicable)
+- HPX vs pure Python comparison
+- Thread scaling tests
+- Different data sizes
+
+## File Checklist
+
+After scaffolding, verify all files are created:
+
+- [ ] `src/<feature_name>.cpp` — C++ implementation
+- [ ] `src/<feature_name>.hpp` — C++ header
+- [ ] `src/bind.cpp` — Updated with new bindings
+- [ ] `CMakeLists.txt` — Updated with new source file
+- [ ] `src/hpyx/<feature_name>/__init__.py` — Python package
+- [ ] `src/hpyx/<feature_name>/_<feature_name>.py` — Python wrapper
+- [ ] `src/hpyx/__init__.py` — Updated exports
+- [ ] `tests/test_<feature_name>.py` — Test suite
+- [ ] `benchmarks/test_bench_<feature_name>.py` — Benchmarks (optional)
+
+## Reference Patterns
+
+Study these existing files as templates:
+- **Pure C++ operation**: `src/algorithms.cpp` (`dot1d`)
+- **Python callback wrapper**: `src/futures.cpp` (`hpx_async`)
+- **Class binding**: `src/bind.cpp` (`bind_hpx_future`)
+- **Python wrapper**: `src/hpyx/futures/_submit.py`
+- **Benchmarks**: `benchmarks/test_bench_hpx_linalg.py`

--- a/plugins/hpx-dev/skills/benchmarking/SKILL.md
+++ b/plugins/hpx-dev/skills/benchmarking/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: benchmarking
+description: Generates `pytest-benchmark` scripts for HPyX bindings, runs HPX vs NumPy/pure-Python comparisons, measures thread scaling and binding overhead, and interprets timing results. Use when the user asks about "benchmarking", "performance testing", "pytest-benchmark", "benchmark HPX vs Python", "benchmark HPX vs NumPy", "measure binding overhead", "profile HPyX", "threadpoolctl", "benchmark scaling", "performance comparison", mentions the "benchmarks/" directory or "pixi run benchmark", or asks about performance characteristics of HPyX operations.
+---
+
+# HPyX Benchmarking
+
+## Benchmark Infrastructure
+
+HPyX uses pytest-benchmark for performance testing:
+
+- **Location**: `benchmarks/` directory
+- **Environment**: `benchmark-py313t` pixi environment
+- **Dependencies**: `pytest-benchmark>=5.1.0`, `threadpoolctl>=3.6.0`
+- **Run command**: `pixi run benchmark`
+
+## Running Benchmarks
+
+```bash
+# Run all benchmarks
+pixi run benchmark
+
+# Run specific benchmarks by keyword
+pixi run benchmark keyword_expression="dot1d"
+
+# The underlying command (for reference):
+pytest ./benchmarks \
+    --benchmark-group-by=func \
+    --benchmark-warmup=on \
+    --benchmark-min-rounds=3 \
+    --benchmark-time-unit=ms
+```
+
+### Useful pytest-benchmark Options
+
+```bash
+# Save results for comparison
+pytest ./benchmarks --benchmark-save=baseline
+
+# Compare against saved results
+pytest ./benchmarks --benchmark-compare=baseline
+
+# Generate JSON output
+pytest ./benchmarks --benchmark-json=results.json
+
+# Disable benchmarks (run tests only)
+pytest ./benchmarks --benchmark-disable
+```
+
+## Benchmark Patterns
+
+### Pattern 1: HPX vs NumPy Comparison
+
+Compare HPyX bindings against NumPy equivalents — the primary benchmark pattern in this project.
+
+```python
+import numpy as np
+import pytest
+from hpyx.runtime import HPXRuntime
+import hpyx
+
+@pytest.mark.parametrize("size", [10_000_000, 50_000_000, 100_000_000])
+def test_bench_hpx_operation(benchmark, size):
+    """Benchmark HPX implementation."""
+    rng = np.random.default_rng()
+    data = rng.random(size)
+    with HPXRuntime():
+        _ = benchmark(hpyx._core.operation, data)
+
+@pytest.mark.parametrize("size", [10_000_000, 50_000_000, 100_000_000])
+def test_bench_numpy_operation(benchmark, size):
+    """Benchmark NumPy equivalent."""
+    rng = np.random.default_rng()
+    data = rng.random(size)
+    _ = benchmark(np.operation, data)
+```
+
+Reference: `benchmarks/test_bench_hpx_linalg.py`
+
+### Pattern 2: Thread Scaling
+
+Measure how performance scales with thread count:
+
+```python
+@pytest.mark.parametrize("threads", [1, 2, 4, 8])
+@pytest.mark.parametrize("size", [1_000_000, 10_000_000])
+def test_bench_scaling(benchmark, threads, size):
+    """Benchmark thread scaling."""
+    data = np.random.random(size)
+    def run():
+        with HPXRuntime(os_threads=threads):
+            return hpyx._core.operation(data)
+    benchmark(run)
+```
+
+### Pattern 3: Single-Thread Controlled Comparison
+
+Use `threadpoolctl` to force single-threaded NumPy for fair comparison:
+
+```python
+from threadpoolctl import threadpool_limits
+
+@pytest.mark.parametrize("size", [10_000_000, 50_000_000])
+def test_bench_hpx_single_thread(benchmark, size):
+    data = np.random.random(size)
+    with HPXRuntime(os_threads=1):
+        _ = benchmark(hpyx._core.operation, data)
+
+@pytest.mark.parametrize("size", [10_000_000, 50_000_000])
+def test_bench_numpy_single_thread(benchmark, size):
+    data = np.random.random(size)
+    with threadpool_limits(limits=1):
+        _ = benchmark(np.operation, data)
+```
+
+Reference: `benchmarks/test_bench_hpx_linalg.py` (single-thread variants)
+
+### Pattern 4: HPX vs Pure Python
+
+Compare against pure Python loops to show binding overhead:
+
+```python
+@pytest.mark.parametrize("size", [100_000, 1_000_000])
+def test_bench_hpx_for_loop(benchmark, size):
+    arr = list(range(size))
+    def run():
+        with HPXRuntime():
+            hpyx.multiprocessing.for_loop(lambda x: x * 2, arr, "seq")
+    benchmark(run)
+
+@pytest.mark.parametrize("size", [100_000, 1_000_000])
+def test_bench_python_for_loop(benchmark, size):
+    arr = list(range(size))
+    def run():
+        for i in range(len(arr)):
+            arr[i] = arr[i] * 2
+    benchmark(run)
+```
+
+### Pattern 5: Binding Overhead Measurement
+
+Isolate the overhead of crossing the Python/C++ boundary:
+
+```python
+def test_bench_submit_overhead(benchmark):
+    """Measure async submit overhead (trivial function)."""
+    with HPXRuntime():
+        def noop():
+            return 42
+        def run():
+            f = hpyx.futures.submit(noop)
+            return f.get()
+        benchmark(run)
+
+def test_bench_python_call_overhead(benchmark):
+    """Baseline: Python function call overhead."""
+    def noop():
+        return 42
+    benchmark(noop)
+```
+
+## Best Practices
+
+### Data Setup Outside Benchmark
+
+Create data before the benchmarked function, not inside it:
+
+```python
+# CORRECT: Data created once, benchmark measures only the operation
+def test_bench(benchmark, size):
+    data = np.random.random(size)  # Outside benchmark
+    with HPXRuntime():
+        _ = benchmark(hpyx._core.dot1d, data, data)
+
+# WRONG: Data creation is measured too
+def test_bench(benchmark, size):
+    def run():
+        data = np.random.random(size)  # Inside benchmark — wrong!
+        return hpyx._core.dot1d(data, data)
+    benchmark(run)
+```
+
+### Runtime Lifecycle in Benchmarks
+
+Place `HPXRuntime()` context based on what to measure:
+
+```python
+# Measure only the operation (exclude runtime startup):
+def test_bench_operation(benchmark, size):
+    data = np.random.random(size)
+    with HPXRuntime():           # Started once
+        _ = benchmark(op, data)  # Operation measured many times
+
+# Measure operation + runtime startup:
+def test_bench_with_startup(benchmark, size):
+    data = np.random.random(size)
+    def run():
+        with HPXRuntime():       # Started each iteration
+            return op(data)
+    benchmark(run)
+```
+
+### Size Ranges
+
+Use parametrize with ranges that reveal scaling behavior:
+
+- **Small**: 100K — 1M elements (shows overhead)
+- **Medium**: 1M — 50M elements (shows steady-state throughput)
+- **Large**: 100M — 500M elements (shows memory bandwidth limits)
+
+### Naming Convention
+
+Follow the pattern `test_bench_{implementation}_{operation}`:
+- `test_bench_hpx_dot1d` — HPX implementation
+- `test_bench_np_dot1d` — NumPy baseline
+- `test_bench_python_for_loop` — Pure Python baseline
+
+## Analyzing Results
+
+Before trusting timing data, verify:
+- HPXRuntime started cleanly (no initialization errors in stderr)
+- Operation results are numerically correct (spot-check against NumPy)
+- StdDev is small relative to Mean — high variance indicates noise or warmup issues
+
+Key metrics to evaluate:
+1. **HPX vs NumPy ratio** — Target: HPX competitive or faster for large data
+2. **Thread scaling efficiency** — Near-linear scaling up to core count
+3. **Binding overhead** — Small constant overhead acceptable for large workloads
+4. **Memory bandwidth** — Operations may be memory-bound at large sizes
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/benchmark-analysis.md`** — Guide to interpreting benchmark results, common performance bottlenecks, and optimization strategies for C++/Python bindings

--- a/plugins/hpx-dev/skills/benchmarking/references/benchmark-analysis.md
+++ b/plugins/hpx-dev/skills/benchmarking/references/benchmark-analysis.md
@@ -1,0 +1,154 @@
+# Benchmark Analysis Guide
+
+Guide to interpreting benchmark results and optimizing HPyX binding performance.
+
+## Understanding pytest-benchmark Output
+
+### Key Metrics
+- **Min**: Fastest iteration — best-case performance, least noise
+- **Max**: Slowest iteration — may include GC pauses, context switches
+- **Mean**: Average across all iterations — most representative
+- **StdDev**: Variation — high StdDev suggests interference (GC, OS scheduling)
+- **Median**: Middle value — robust against outliers
+- **Rounds**: Number of benchmark iterations — more rounds = more reliable
+- **OPS**: Operations per second — inverse of mean time
+
+### Which Metric to Use
+- **Comparing implementations**: Use **median** (robust to outliers)
+- **Worst-case analysis**: Use **max** (but discount GC pauses)
+- **Best achievable**: Use **min** (shows theoretical maximum)
+- **Reporting**: Use **mean ± StdDev** (standard practice)
+
+## Common Performance Patterns
+
+### Pattern 1: Binding Overhead Dominates (Small Data)
+
+```
+HPX dot1d (1K elements):   0.05 ms
+NumPy dot  (1K elements):  0.001 ms
+```
+
+**Diagnosis**: For small data, the cost of crossing Python→C++→HPX exceeds computation time.
+
+**Action**: This is expected. Document the crossover point where HPX becomes faster. Typical crossover: 100K-1M elements.
+
+### Pattern 2: Memory Bandwidth Limit (Large Data)
+
+```
+HPX dot1d (500M elements): 250 ms
+NumPy dot  (500M elements): 240 ms
+```
+
+**Diagnosis**: At very large sizes, both implementations saturate memory bandwidth. Parallel execution doesn't help because all cores share the memory bus.
+
+**Action**: Expected for memory-bound operations. Report bandwidth utilization: `2 * N * sizeof(double) / time = GB/s`.
+
+### Pattern 3: Linear Thread Scaling
+
+```
+1 thread:  100 ms
+2 threads:  52 ms (1.92x)
+4 threads:  27 ms (3.70x)
+8 threads:  15 ms (6.67x)
+```
+
+**Diagnosis**: Near-linear scaling indicates compute-bound workload with good load balancing.
+
+**Action**: Ideal result. Report scaling efficiency: `speedup / threads * 100%`.
+
+### Pattern 4: GIL Contention (Python Callbacks)
+
+```
+HPX for_loop (par, Python callback): 150 ms
+HPX for_loop (seq, Python callback):  50 ms
+Pure Python loop:                      45 ms
+```
+
+**Diagnosis**: Parallel execution with Python callbacks is slower than sequential because the GIL serializes Python calls.
+
+**Action**: This is a known limitation with GIL-enabled Python. With free-threading (Python 3.13t), parallel Python callbacks should scale better. For GIL-enabled builds, recommend pure C++ lambdas for parallel work.
+
+### Pattern 5: Runtime Startup Overhead
+
+```
+With runtime in benchmark:  500 ms (first), 15 ms (subsequent)
+Without runtime in benchmark: 15 ms
+```
+
+**Diagnosis**: HPXRuntime initialization is expensive (~200-500ms).
+
+**Action**: Always initialize runtime outside the benchmark loop. Document startup cost separately.
+
+## Optimization Strategies
+
+### For Compute-Bound Operations
+1. Increase thread count (`HPXRuntime(os_threads=N)`)
+2. Use `par_unseq` policy for vectorization
+3. Minimize Python callback overhead (use pure C++ when possible)
+
+### For Memory-Bound Operations
+1. Process data in cache-friendly chunks
+2. Use NUMA-aware allocation on multi-socket systems
+3. Avoid unnecessary copies between Python and C++
+
+### For Reducing Binding Overhead
+1. Batch operations (process arrays, not scalars)
+2. Use ndarray for zero-copy data transfer
+3. Minimize Python↔C++ round trips
+
+### For GIL Contention
+1. Use free-threading Python (3.13t)
+2. Keep Python callbacks minimal
+3. Do bulk work in C++ and only return results to Python
+4. Use deferred execution to avoid true parallel GIL acquisition
+
+## Benchmarking Best Practices
+
+### Controlling Variables
+- Pin to specific CPU cores: `taskset -c 0-3 python benchmark.py`
+- Disable CPU frequency scaling: `cpupower frequency-set -g performance`
+- Close other applications
+- Run multiple times and check consistency
+
+### Statistical Validity
+- Use `--benchmark-min-rounds=5` minimum
+- Check StdDev < 10% of Mean
+- If StdDev is high, increase rounds or check for interference
+- Use `--benchmark-warmup=on` to exclude JIT/cache warming
+
+### Comparing Results Over Time
+```bash
+# Save baseline
+pytest benchmarks/ --benchmark-save=baseline
+
+# After changes, compare
+pytest benchmarks/ --benchmark-compare=baseline
+
+# Generate JSON for automated analysis
+pytest benchmarks/ --benchmark-json=results.json
+```
+
+### Reporting Template
+
+```markdown
+## Performance Report: <feature>
+
+**Environment:**
+- CPU: [model, cores, frequency]
+- Memory: [size, speed]
+- Python: 3.13 (free-threading: yes/no)
+- HPX: [version]
+- NumPy: [version]
+
+**Results:**
+[Table with implementations, sizes, timings]
+
+**Key Findings:**
+1. Crossover point: HPX faster than NumPy at [N] elements
+2. Thread scaling: [X]% efficiency at [N] threads
+3. Binding overhead: [Y] ms constant cost
+4. Memory bandwidth utilization: [Z] GB/s
+
+**Recommendations:**
+- [Optimization suggestions]
+```

--- a/plugins/hpx-dev/skills/build-system/SKILL.md
+++ b/plugins/hpx-dev/skills/build-system/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: build-system
+description: Guides building and configuring HPyX (CMake + scikit-build-core + Nanobind + pixi), diagnoses CMake/compilation/link errors, explains `nanobind_add_module` usage, configures conda-forge dependencies, and resolves RPATH issues. Use when the user asks about "build system", "CMake configuration", "scikit-build-core", "pixi", "build errors", "compilation errors", "link errors", "nanobind_add_module", "CMakeLists.txt", "pyproject.toml", "pixi.toml", "build HPX from source", "install dependencies", "RPATH", "conda-forge", or hits build failures, missing library errors, or environment setup issues.
+---
+
+# HPyX Build System
+
+## Build Stack Overview
+
+```
+pixi.toml          → Environment & dependency management (conda-forge + PyPI)
+pyproject.toml      → Python package metadata + scikit-build-core config
+CMakeLists.txt      → C++ compilation, Nanobind module, HPX linking
+```
+
+The build flow:
+1. `pixi` resolves and installs all dependencies (HPX, Nanobind, compilers, Python 3.13t)
+2. `pip install -e .` (or `pixi run test`) triggers scikit-build-core
+3. scikit-build-core invokes CMake to compile the `_core` Nanobind module
+4. CMake finds HPX, Nanobind, and Python, then links everything together
+5. The compiled `_core.so` / `_core.pyd` is installed into the `hpyx` package
+
+## Pixi Environments
+
+Key environments defined in `pixi.toml`:
+
+| Environment | Purpose | Features |
+|---|---|---|
+| `py313t` | Default development | Python 3.13 free-threading + HPX + HPyX |
+| `test-py313t` | Testing | Above + pytest |
+| `benchmark-py313t` | Benchmarking | Above + pytest-benchmark + threadpoolctl |
+| `build-py313t` | Distribution builds | Python 3.13 free-threading + build tools |
+| `docs` | Documentation | Python 3.13 + MkDocs |
+| `linting` | Code quality | Python 3.13 + pre-commit |
+| `py313t-src` | Build HPX from source | Python 3.13 free-threading + HPX build deps |
+
+Common pixi commands:
+```bash
+pixi shell -e py313t          # Enter dev environment
+pixi run test                  # Run tests
+pixi run benchmark             # Run benchmarks
+pixi run lint                  # Run linters
+pixi run -e docs start         # Start docs server
+```
+
+## CMake Configuration
+
+The `CMakeLists.txt` key sections:
+
+### Finding Dependencies
+```cmake
+find_package(Python 3.13 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(nanobind CONFIG REQUIRED)
+find_package(HPX REQUIRED)
+```
+
+### Building the Module
+```cmake
+nanobind_add_module(
+  _core
+  FREE_THREADED          # Required for Python 3.13 free-threading
+  src/bind.cpp
+  src/init_hpx.cpp
+  src/algorithms.cpp
+  src/futures.cpp
+  # Add new source files here
+)
+```
+
+### Linking HPX Libraries
+```cmake
+target_link_libraries(_core PRIVATE
+  HPX::hpx
+  HPX::wrap_main
+  HPX::iostreams_component
+)
+```
+
+### Adding a New Source File
+
+1. Create `src/new_feature.cpp` and `src/new_feature.hpp`
+2. Add to `nanobind_add_module()`:
+   ```cmake
+   nanobind_add_module(
+     _core
+     FREE_THREADED
+     src/bind.cpp
+     src/init_hpx.cpp
+     src/algorithms.cpp
+     src/futures.cpp
+     src/new_feature.cpp    # New file
+   )
+   ```
+3. If the new feature needs additional HPX components, add to `target_link_libraries`:
+   ```cmake
+   target_link_libraries(_core PRIVATE
+     HPX::hpx
+     HPX::wrap_main
+     HPX::iostreams_component
+     HPX::new_component       # Additional HPX component
+   )
+   ```
+
+## pyproject.toml Key Settings
+
+```toml
+[build-system]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.7.0"]
+build-backend = "scikit_build_core.build"
+
+[tool.scikit-build]
+wheel.packages = ["src/hpyx"]
+```
+
+The `src/` layout means Python sources live in `src/hpyx/` while C++ sources are in `src/` at the project root.
+
+## Building HPX from Source
+
+When the latest HPX version is not yet on conda-forge:
+
+```bash
+pixi shell -e py313t-src
+pixi run build-hpx tag=v1.11.0-rc1
+pixi run install-latest-lib
+```
+
+This uses `scripts/build.sh` to:
+1. Checkout the specified HPX version in `vendor/hpx/`
+2. Build HPX with CMake + Ninja
+3. Install to the pixi environment prefix
+
+## Common Build Issues
+
+### Missing HPX Package
+```
+Could not find a package configuration file provided by "HPX"
+```
+**Fix**: Ensure HPX is installed: `pixi shell -e py313t` (conda-forge provides HPX)
+
+### Nanobind Not Found
+```
+Could not find a configuration file for package "nanobind"
+```
+**Fix**: Run `pip install nanobind>=2.7.0` or ensure the pixi environment is active
+
+### RPATH Issues on macOS
+```
+dyld: Library not loaded...
+```
+**Fix**: The CMakeLists.txt sets `CMAKE_INSTALL_RPATH "$ORIGIN"`. On macOS, the `dynamic_lookup` flag handles Python symbol resolution. Ensure building within the pixi environment.
+
+### Link Errors with HPX Components
+```
+undefined reference to `hpx::some_function`
+```
+**Fix**: Add the missing HPX component to `target_link_libraries`. Check which HPX target provides the symbol by searching `vendor/hpx/cmake/`.
+
+### Rebuild After C++ Changes
+```bash
+pip install --no-build-isolation -ve .   # Editable install, fast rebuild
+# Or with auto-rebuild on import:
+pip install --no-build-isolation -ve . -Ceditable.rebuild=true
+```
+
+## Development Workflow
+
+```bash
+# 1. Enter dev environment
+pixi shell -e py313t
+
+# 2. Edit C++ source files
+
+# 3. Rebuild (fast, editable)
+pip install --no-build-isolation -ve .
+
+# 4. Verify the rebuild: _core.*.so should exist under src/hpyx/
+ls src/hpyx/_core*.so
+
+# 5. Test
+pixi run test
+
+# 5. Benchmark (optional)
+pixi run benchmark
+```

--- a/plugins/hpx-dev/skills/gil-management/SKILL.md
+++ b/plugins/hpx-dev/skills/gil-management/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: gil-management
+description: Enforces correct GIL handling in HPyX's Nanobind bindings under Python 3.13 free-threading — diagnoses GIL deadlocks and callback segfaults, applies `gil_scoped_acquire`/`release` patterns, and validates thread safety in C++/Python code. Use when the user asks about "GIL management", "free-threading", "Python 3.13 free-threading", "gil_scoped_acquire", "gil_scoped_release", "thread safety", "GIL deadlock", "nogil", "disable-gil", or debugs threading issues, segfaults in callbacks, or race conditions in HPyX.
+---
+
+# GIL and Free-Threading Management
+
+## HPyX Threading Model
+
+HPyX targets Python 3.13 with free-threading (`--disable-gil`). The `_core` module is compiled with Nanobind's `FREE_THREADED` flag. Thread safety must be ensured through proper synchronization, not GIL reliance; `nb::gil_scoped_acquire` is a no-op when the GIL is disabled. HPX manages its own thread pool independently of Python's threading.
+
+## GIL Rules for HPyX Bindings
+
+### Rule 1: Acquire GIL Before Calling Python
+
+Any C++ code that calls into Python (invoking callables, accessing Python objects, creating Python objects) must hold the GIL:
+
+```cpp
+// CORRECT: GIL acquired before Python callback
+hpx::async(hpx::launch::deferred,
+    [f, args]() -> nb::object {
+        nb::gil_scoped_acquire acquire;  // Acquire before Python call
+        return f(*args);
+    });
+```
+
+```cpp
+// WRONG: Calling Python without GIL — will segfault or corrupt state
+hpx::async(hpx::launch::deferred,
+    [f, args]() -> nb::object {
+        return f(*args);  // DANGER: no GIL
+    });
+```
+
+### Rule 2: Release GIL During Blocking C++ Operations
+
+Long-running pure C++ operations should release the GIL to allow other Python threads to execute:
+
+```cpp
+// CORRECT: GIL released during HPX shutdown (blocking operation)
+void stop_hpx_runtime() {
+    global_runtime_manager *r = rts;
+    rts = nullptr;
+    if (r != nullptr) {
+        nb::gil_scoped_release release;  // Release during blocking C++ work
+        delete r;
+    }
+}
+```
+
+### Rule 3: Deferred Futures Keep GIL for Callbacks
+
+HPyX uses `hpx::launch::deferred` for futures that invoke Python callbacks. The callable runs in the caller's thread at `.get()` time, so the GIL is already held:
+
+```cpp
+// The .get() method does NOT release the GIL because the deferred
+// callable may call back into Python
+.def("get", [](hpx::future<T> &f) {
+    return f.get();  // Runs deferred callable in caller's thread
+})
+```
+
+### Rule 4: .then() Continuations Need Explicit GIL
+
+When chaining futures with `.then()`, the continuation creates a new deferred future that must acquire the GIL before invoking the Python callback:
+
+```cpp
+.def("then", [](hpx::future<T> &f, nb::callable callback, nb::args args) {
+    hpx::future<T> cont = hpx::async(hpx::launch::deferred,
+        [prev = std::move(f), callback, args]() mutable -> nb::object {
+            nb::gil_scoped_acquire acquire;  // Must acquire for Python callback
+            auto res = prev.get();
+            return callback(res, *args);
+        });
+    return cont;
+})
+```
+
+## Decision Matrix
+
+| Scenario | GIL Action | Reason |
+|---|---|---|
+| C++ code calling `nb::callable` | `gil_scoped_acquire` | Python objects require GIL |
+| C++ code creating `nb::object` | `gil_scoped_acquire` | Python heap allocation |
+| Pure C++ computation (no Python) | No action needed (or `gil_scoped_release` if called from Python) | No Python interaction |
+| Blocking C++ operation (runtime shutdown, network I/O) | `gil_scoped_release` | Allow other Python threads to proceed |
+| Nanobind `.def()` method body | GIL is held by default | Nanobind acquires GIL for method calls |
+| HPX async lambda (deferred, with Python callback) | `gil_scoped_acquire` inside lambda | Lambda runs in HPX thread, not Python thread |
+| HPX async lambda (deferred, pure C++) | No GIL needed inside lambda | No Python interaction |
+
+## Free-Threading Considerations
+
+With Python 3.13 free-threading, `nb::gil_scoped_acquire` / `release` become no-ops. This means:
+
+- **Thread safety cannot rely on the GIL** — use proper synchronization (mutexes, atomics) for shared state
+- **Python reference counting is thread-safe** in free-threading mode (uses atomic refcounts)
+- **Nanobind's FREE_THREADED flag** ensures the module supports free-threading correctly
+- **HPX thread pool** operates independently — HPX threads are not Python threads
+
+### Shared State Protection
+
+```cpp
+// CORRECT: Use mutex for shared state in free-threading
+std::mutex mtx;
+std::vector<nb::object> results;
+
+hpx::for_each(hpx::execution::par, begin, end,
+    [&](auto item) {
+        nb::gil_scoped_acquire acquire;
+        auto result = process(item);
+        std::lock_guard<std::mutex> lock(mtx);
+        results.push_back(result);
+    });
+```
+
+## Debugging GIL Issues
+
+Common symptoms and causes:
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Segfault in Python callback | Missing `gil_scoped_acquire` | Add acquire before Python calls |
+| Deadlock on `.get()` | GIL held while waiting for future that needs GIL | Release GIL before `.get()` or use deferred launch |
+| Corrupted Python objects | Race condition in free-threading | Add mutex around shared Python object access |
+| "Fatal Python error: GIL not held" | Missing acquire in non-deferred async | Add `gil_scoped_acquire` in async lambda |
+
+## HPyX-Specific Patterns
+
+### Runtime Initialization
+
+The runtime manager (`src/init_hpx.cpp`) acquires the GIL during init and releases during shutdown:
+
+```
+init_hpx_runtime() → gil_scoped_acquire (ensures Python is safe during setup)
+stop_hpx_runtime() → gil_scoped_release (allows Python threads during HPX shutdown)
+```
+
+### The Deferred Execution Pattern
+
+HPyX currently uses `hpx::launch::deferred` for all Python-facing async operations. This simplifies GIL management because:
+
+1. Deferred futures don't execute until `.get()` is called
+2. `.get()` runs in the caller's thread (which holds the GIL from Python)
+3. No true parallel Python execution occurs — parallelism is in pure C++ operations
+
+When implementing true parallel execution (non-deferred), switch to `hpx::launch::async` and ensure every lambda that touches Python acquires the GIL.

--- a/plugins/hpx-dev/skills/hpx-architecture/SKILL.md
+++ b/plugins/hpx-dev/skills/hpx-architecture/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: hpx-architecture
+description: Maps HPX C++ library components to their `vendor/hpx/` source locations, tracks which HPX features are already wrapped in HPyX, and identifies unwrapped candidates for new Python bindings. Use when the user asks about "HPX architecture", "HPX components", "HPX APIs", "what HPX features to wrap", "HPX parallel algorithms", "HPX futures", "HPX distributed computing", "HPX AGAS", "HPX performance counters", "HPX execution policies", or mentions "vendor/hpx", "HPX source", or asks what parts of HPX are available for binding.
+---
+
+# HPX Architecture Knowledge
+
+## HPyX-Specific Context
+
+The HPX source lives at `vendor/hpx/` as a git submodule. Key source directories:
+
+- `vendor/hpx/libs/` — Core library modules (algorithms, futures, threading, etc.)
+- `vendor/hpx/components/` — Runtime components (performance counters, iostreams)
+- `vendor/hpx/examples/` — C++ usage examples
+- `vendor/hpx/docs/sphinx/` — Official documentation
+
+## Currently Wrapped in HPyX
+
+The following HPX features have Python bindings in `src/`:
+
+| HPX Feature | C++ Source | Python API |
+|---|---|---|
+| `hpx::async` (deferred) | `src/futures.cpp` | `hpyx.futures.submit()` |
+| `hpx::future<T>` | `src/bind.cpp` | `hpyx._core.future` |
+| `hpx::experimental::for_loop` | `src/algorithms.cpp` | `hpyx.multiprocessing.for_loop()` |
+| `hpx::transform_reduce` (dot product) | `src/algorithms.cpp` | `hpyx._core.dot1d()` |
+| Runtime init/shutdown | `src/init_hpx.cpp` | `hpyx._core.init_hpx_runtime()` / `stop_hpx_runtime()` |
+| `hpx::get_num_worker_threads` | `src/bind.cpp` | `hpyx._core.get_num_worker_threads()` |
+
+## Unwrapped HPX Features (Candidates for Binding)
+
+### High Priority — Parallel Algorithms (`vendor/hpx/libs/core/algorithms/`)
+
+- `hpx::for_each` — Apply function to range (parallel)
+- `hpx::transform` — Transform range into output
+- `hpx::reduce` — Parallel reduction
+- `hpx::sort` / `hpx::stable_sort` — Parallel sorting
+- `hpx::count` / `hpx::count_if` — Parallel counting
+- `hpx::find` / `hpx::find_if` — Parallel search
+- `hpx::copy` / `hpx::copy_if` — Parallel copy
+- `hpx::fill` — Parallel fill
+- `hpx::transform_reduce` — Fused transform + reduce (partially wrapped as `dot1d`)
+- `hpx::inclusive_scan` / `hpx::exclusive_scan` — Prefix sums
+
+### High Priority — Execution Policies
+
+- `hpx::execution::seq` — Sequential (wrapped)
+- `hpx::execution::par` — Parallel (partially wrapped)
+- `hpx::execution::par_unseq` — Parallel unsequenced
+- `hpx::execution::task` — Returns future instead of blocking
+- Custom executors for thread pool control
+
+### Medium Priority — Synchronization & Concurrency
+
+- `hpx::latch` — Thread synchronization barrier
+- `hpx::barrier` — Reusable barrier
+- `hpx::mutex` / `hpx::shared_mutex` — Lightweight mutexes
+- `hpx::when_all` / `hpx::when_any` — Future combinators
+- `hpx::dataflow` — Dataflow-based task execution
+
+### Future Work — Distributed Computing
+
+- `hpx::find_here()` / `hpx::find_all_localities()` — Locality discovery
+- `hpx::components` — Distributed objects
+- `hpx::actions` — Remote procedure calls
+- AGAS (Active Global Address Space) — Distributed naming
+- Parcelport — Network transport layer
+- TCP/MPI parcelports for inter-node communication
+
+### Utility — Performance Counters
+
+- `hpx::performance_counters` — Runtime metrics
+- Thread scheduling statistics
+- Memory allocation tracking
+- Network bandwidth monitoring
+
+## Key HPX Headers
+
+When adding new bindings, include the appropriate HPX headers:
+
+```cpp
+#include <hpx/algorithm.hpp>     // Parallel algorithms
+#include <hpx/future.hpp>        // Futures
+#include <hpx/numeric.hpp>       // Numeric algorithms
+#include <hpx/execution.hpp>     // Execution policies
+#include <hpx/hpx_start.hpp>     // Runtime management
+#include <hpx/iostream.hpp>      // HPX I/O streams
+#include <hpx/latch.hpp>         // Synchronization primitives
+#include <hpx/version.hpp>       // Version info
+```
+
+## Execution Policy Model
+
+HPX execution policies control how algorithms dispatch work:
+
+```
+seq          → Single thread, caller's thread
+par          → HPX thread pool, parallel tasks
+par_unseq    → Parallel + vectorization hints
+task(policy) → Returns future<result> instead of blocking
+```
+
+When binding algorithms, always expose the `policy` parameter to Python to let users choose between sequential and parallel execution.
+
+## Additional Resources
+
+### Reference Files
+
+For detailed HPX API documentation and component maps:
+- **`references/hpx-api-map.md`** — Comprehensive map of HPX APIs organized by module with binding feasibility notes
+- **`references/hpx-distributed.md`** — Detailed guide to HPX distributed computing features (AGAS, actions, components, parcelports)

--- a/plugins/hpx-dev/skills/hpx-architecture/references/hpx-api-map.md
+++ b/plugins/hpx-dev/skills/hpx-architecture/references/hpx-api-map.md
@@ -1,0 +1,114 @@
+# HPX API Map for Binding Development
+
+Comprehensive map of HPX APIs organized by module, with binding feasibility notes for HPyX.
+
+## Parallel Algorithms (`<hpx/algorithm.hpp>`)
+
+All algorithms support execution policies: `seq`, `par`, `par_unseq`, `task`.
+
+### Sorting & Ordering
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::sort` | `<hpx/algorithm.hpp>` | Medium | Needs comparison callable, GIL for Python comparator |
+| `hpx::stable_sort` | `<hpx/algorithm.hpp>` | Medium | Same as sort |
+| `hpx::partial_sort` | `<hpx/algorithm.hpp>` | Medium | Needs nth element parameter |
+| `hpx::is_sorted` | `<hpx/algorithm.hpp>` | Low | Returns bool, straightforward |
+
+### Searching
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::find` | `<hpx/algorithm.hpp>` | Low | Returns iterator → index in Python |
+| `hpx::find_if` | `<hpx/algorithm.hpp>` | Medium | Needs predicate callable, GIL |
+| `hpx::count` | `<hpx/algorithm.hpp>` | Low | Returns count, straightforward |
+| `hpx::count_if` | `<hpx/algorithm.hpp>` | Medium | Needs predicate callable |
+| `hpx::any_of` / `all_of` / `none_of` | `<hpx/algorithm.hpp>` | Medium | Predicate callable |
+
+### Transformations
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::for_each` | `<hpx/algorithm.hpp>` | Medium | Similar to existing for_loop |
+| `hpx::transform` | `<hpx/algorithm.hpp>` | Medium | Output range needed |
+| `hpx::copy` / `copy_if` | `<hpx/algorithm.hpp>` | Low-Medium | Iterator-based |
+| `hpx::fill` | `<hpx/algorithm.hpp>` | Low | Simple value fill |
+| `hpx::generate` | `<hpx/algorithm.hpp>` | Medium | Generator callable |
+| `hpx::replace` / `replace_if` | `<hpx/algorithm.hpp>` | Low-Medium | In-place modification |
+| `hpx::reverse` | `<hpx/algorithm.hpp>` | Low | In-place |
+| `hpx::rotate` | `<hpx/algorithm.hpp>` | Low | In-place |
+| `hpx::unique` | `<hpx/algorithm.hpp>` | Medium | Returns new end iterator |
+
+### Reductions
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::reduce` | `<hpx/numeric.hpp>` | Low-Medium | Binary op callable |
+| `hpx::transform_reduce` | `<hpx/numeric.hpp>` | Medium | Partially wrapped as dot1d |
+| `hpx::inclusive_scan` | `<hpx/numeric.hpp>` | Medium | Output range needed |
+| `hpx::exclusive_scan` | `<hpx/numeric.hpp>` | Medium | Output range + init value |
+| `hpx::transform_inclusive_scan` | `<hpx/numeric.hpp>` | High | Fused operation |
+| `hpx::transform_exclusive_scan` | `<hpx/numeric.hpp>` | High | Fused operation |
+
+## Futures & Async (`<hpx/future.hpp>`)
+
+### Future Combinators
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::when_all` | `<hpx/future.hpp>` | Medium | Takes vector of futures, returns future of vector |
+| `hpx::when_any` | `<hpx/future.hpp>` | Medium | Returns first completed future |
+| `hpx::when_each` | `<hpx/future.hpp>` | High | Callback for each completion |
+| `hpx::when_some` | `<hpx/future.hpp>` | High | Wait for N completions |
+| `hpx::dataflow` | `<hpx/future.hpp>` | High | Dataflow graph execution |
+| `hpx::make_ready_future` | `<hpx/future.hpp>` | Low | Creates pre-completed future |
+
+### Async Variants
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::async` (async launch) | `<hpx/future.hpp>` | Medium | True parallel execution, complex GIL |
+| `hpx::async` (deferred launch) | `<hpx/future.hpp>` | Low | Already wrapped |
+| `hpx::async` (fork launch) | `<hpx/future.hpp>` | Medium | Child-stealing, complex |
+
+## Synchronization (`<hpx/latch.hpp>`, `<hpx/barrier.hpp>`)
+
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::latch` | `<hpx/latch.hpp>` | Medium | Count-down synchronization |
+| `hpx::barrier` | `<hpx/barrier.hpp>` | Medium | Reusable barrier |
+| `hpx::mutex` | `<hpx/mutex.hpp>` | Medium | Lightweight mutex |
+| `hpx::shared_mutex` | `<hpx/shared_mutex.hpp>` | Medium | Reader-writer lock |
+| `hpx::condition_variable` | `<hpx/condition_variable.hpp>` | High | Complex lifetime |
+
+## Execution Policies & Executors (`<hpx/execution.hpp>`)
+
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::execution::seq` | `<hpx/execution.hpp>` | Low | Already used |
+| `hpx::execution::par` | `<hpx/execution.hpp>` | Low | Already used |
+| `hpx::execution::par_unseq` | `<hpx/execution.hpp>` | Low | Vectorization hint |
+| `hpx::execution::task` | `<hpx/execution.hpp>` | Medium | Returns future |
+| Custom executors | `<hpx/execution.hpp>` | High | Thread pool control |
+
+## Distributed Computing
+
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::find_here()` | `<hpx/runtime.hpp>` | Low | Returns locality ID |
+| `hpx::find_all_localities()` | `<hpx/runtime.hpp>` | Low | Returns locality IDs |
+| `hpx::components` | Various | High | Distributed objects, complex |
+| `hpx::actions` | Various | High | Remote procedure calls |
+| AGAS | Various | Very High | Active Global Address Space |
+| Parcelport (TCP) | Various | High | Network transport |
+| Parcelport (MPI) | Various | High | MPI transport |
+
+## Performance Counters
+
+| API | Header | Binding Feasibility | Notes |
+|---|---|---|---|
+| `hpx::performance_counters::get_counter` | Various | Medium | Query runtime metrics |
+| Thread idle rates | Various | Medium | Scheduling efficiency |
+| Queue lengths | Various | Medium | Work distribution |
+| Memory usage | Various | Medium | Allocation tracking |
+
+## Binding Feasibility Legend
+
+- **Low**: Straightforward binding, minimal GIL concerns, direct type mapping
+- **Medium**: Requires GIL management for callbacks, iterator→index translation, or output buffer management
+- **High**: Complex template metaprogramming, lifetime management, or distributed state
+- **Very High**: Requires significant design work, may need new architectural patterns

--- a/plugins/hpx-dev/skills/hpx-architecture/references/hpx-distributed.md
+++ b/plugins/hpx-dev/skills/hpx-architecture/references/hpx-distributed.md
@@ -1,0 +1,192 @@
+# HPX Distributed Computing Guide
+
+Detailed guide to HPX's distributed computing features for future HPyX binding development.
+
+## Overview
+
+HPX's distributed computing model is built on three pillars:
+1. **AGAS (Active Global Address Space)** — Global naming and object location
+2. **Actions** — Remote procedure calls
+3. **Components** — Distributed objects with remote interfaces
+
+These features require the TCP or MPI parcelport to be enabled (`tcp_enable=True` in HPXRuntime).
+
+## AGAS — Active Global Address Space
+
+AGAS provides transparent object location and migration across localities (nodes).
+
+### Key Concepts
+- **Locality**: A single process (node) in the HPX runtime
+- **GID (Global ID)**: Unique identifier for any object across all localities
+- **id_type**: HPX's global reference type, wraps a GID
+
+### Core APIs
+```cpp
+// Get current locality
+hpx::id_type here = hpx::find_here();
+
+// Get all localities
+std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+// Get number of localities
+std::size_t n = hpx::get_num_localities().get();
+
+// Get locality of an object
+hpx::id_type loc = hpx::get_colocation_id(object_id).get();
+```
+
+### Binding Strategy for Python
+Expose locality discovery first:
+```python
+# Proposed Python API
+from hpyx.distributed import get_locality, get_all_localities, get_num_localities
+
+with HPXRuntime(tcp_enable=True):
+    here = get_locality()          # Current node
+    all_locs = get_all_localities() # All nodes
+    n = get_num_localities()        # Count
+```
+
+## Actions — Remote Procedure Calls
+
+Actions wrap functions for remote invocation. HPX automatically serializes arguments, sends them to the target locality, executes the function, and returns the result as a future.
+
+### Types of Actions
+1. **Plain actions**: Wrap free functions
+2. **Component actions**: Wrap member functions of components
+
+### Definition Pattern (C++)
+```cpp
+// Define a plain action
+int compute(int x) { return x * x; }
+HPX_PLAIN_ACTION(compute, compute_action);
+
+// Invoke remotely
+hpx::id_type target_locality = ...;
+hpx::future<int> result = hpx::async(compute_action{}, target_locality, 42);
+```
+
+### Binding Challenges
+- Actions require HPX macros (`HPX_PLAIN_ACTION`) at compile time
+- Python callables cannot be directly converted to HPX actions
+- Serialization of Python objects across nodes is non-trivial
+
+### Proposed Binding Strategy
+Create pre-defined C++ actions that accept serializable data types (arrays, scalars, strings) and wrap common parallel patterns:
+```python
+# Proposed: Pre-built distributed algorithms
+from hpyx.distributed import distributed_reduce, distributed_map
+
+with HPXRuntime(tcp_enable=True):
+    # Scatter data across localities, reduce results
+    result = distributed_reduce(data, operation="sum")
+
+    # Map a pre-registered function across localities
+    results = distributed_map("compute_function_name", chunks)
+```
+
+## Components — Distributed Objects
+
+Components are C++ objects with a globally unique identity that can be accessed from any locality.
+
+### Key Concepts
+- Components are managed by AGAS
+- They have actions (remote-callable methods)
+- They can migrate between localities
+- Lifecycle managed through shared ownership (like `shared_ptr`)
+
+### Definition Pattern (C++)
+```cpp
+// Server side (where component lives)
+struct my_component : hpx::components::component_base<my_component>
+{
+    int compute(int x) { return x * x; }
+    HPX_DEFINE_COMPONENT_ACTION(my_component, compute, compute_action);
+};
+
+// Client side (remote access)
+struct my_client : hpx::components::client_base<my_client, my_component>
+{
+    hpx::future<int> compute(int x) {
+        return hpx::async(my_component::compute_action{}, this->get_id(), x);
+    }
+};
+```
+
+### Binding Strategy
+Create a Python wrapper that abstracts the component pattern:
+```python
+# Proposed: Distributed object pattern
+from hpyx.distributed import DistributedArray
+
+with HPXRuntime(tcp_enable=True):
+    # Create array distributed across localities
+    darr = DistributedArray(data, num_partitions=4)
+
+    # Operations automatically distributed
+    result = darr.reduce(operation="sum")
+    transformed = darr.map(lambda x: x * 2)  # Requires serialization strategy
+```
+
+## Parcelports — Network Transport
+
+Parcelports handle network communication between localities.
+
+### Available Transports
+- **TCP**: Default, works everywhere
+- **MPI**: High-performance, requires MPI installation
+- **LCI**: Lightweight Communication Interface (experimental)
+
+### Configuration
+```python
+# TCP (default distributed transport)
+with HPXRuntime(tcp_enable=True):
+    pass
+
+# MPI (via HPX config)
+cfg = ["hpx.parcel.mpi.enable!=1"]
+hpyx._core.init_hpx_runtime(cfg)
+```
+
+### Multi-Node Execution
+```bash
+# TCP transport
+mpirun -np 4 python my_script.py --hpx:threads=4
+
+# With explicit localities
+python my_script.py --hpx:localities=4 --hpx:threads=4
+```
+
+## Implementation Roadmap for HPyX
+
+### Phase 1: Locality Discovery (Low complexity)
+- `hpx::find_here()` → `hpyx.distributed.get_locality()`
+- `hpx::find_all_localities()` → `hpyx.distributed.get_all_localities()`
+- `hpx::get_num_localities()` → `hpyx.distributed.get_num_localities()`
+
+### Phase 2: Remote Execution (Medium complexity)
+- Pre-built C++ actions for common operations (reduce, map, scatter, gather)
+- Python API for invoking pre-built distributed algorithms
+- Data serialization via NumPy arrays (binary-compatible)
+
+### Phase 3: Distributed Data Structures (High complexity)
+- Distributed arrays with partitioned storage
+- Automatic data distribution across localities
+- Collective operations on distributed data
+
+### Phase 4: Custom Actions (Very high complexity)
+- Runtime action registration from Python
+- Python callable serialization strategy
+- Hybrid approach: C++ actions with Python configuration
+
+## Key HPX Source Locations
+
+```
+vendor/hpx/libs/full/actions/         — Action framework
+vendor/hpx/libs/full/actions_base/    — Action base classes
+vendor/hpx/libs/full/agas/            — AGAS implementation
+vendor/hpx/libs/full/collectives/     — Collective operations
+vendor/hpx/libs/full/components/      — Component framework
+vendor/hpx/libs/full/distribution_policies/ — Data distribution
+vendor/hpx/libs/full/parcelports/     — Network transports
+```

--- a/plugins/hpx-dev/skills/nanobind-patterns/SKILL.md
+++ b/plugins/hpx-dev/skills/nanobind-patterns/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: nanobind-patterns
+description: Writes Nanobind C++-to-Python bindings for HPX APIs following HPyX conventions — generates `m.def` function bindings, `nb::class_` wrappers, type conversions, and `nb::ndarray` patterns. Use when the user asks to "create a binding", "write nanobind code", "wrap a C++ function", "add a new HPX binding", "bind a C++ class", "expose C++ to Python", "nanobind template", "type conversion", "ndarray binding", or works in files under `src/*.cpp` or `src/*.hpp`.
+---
+
+# Nanobind Binding Patterns for HPyX
+
+## HPyX Binding Architecture
+
+HPyX uses a 3-layer architecture:
+
+1. **C++ Binding Layer** (`src/*.cpp`) — Nanobind wrappers around HPX APIs
+2. **Python API Layer** (`src/hpyx/*.py`) — Pythonic high-level wrappers
+3. **Module Entry Point** (`src/bind.cpp`) — `NB_MODULE(_core, m)` registration
+
+All bindings compile into a single `_core` module with the `FREE_THREADED` flag for Python 3.13 free-threading support.
+
+## Pattern: Wrapping a Pure C++ Function
+
+For HPX functions that do not call back into Python (e.g., numeric operations on raw data):
+
+```cpp
+// In src/new_feature.cpp
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <hpx/algorithm.hpp>
+
+namespace nb = nanobind;
+
+namespace new_feature {
+
+double compute(
+    nb::ndarray<nb::numpy, const double, nb::c_contig> input)
+{
+    const double* data = input.data();
+    std::size_t size = input.size();
+
+    // No GIL management needed — pure C++ computation
+    return hpx::reduce(
+        hpx::execution::par,
+        data, data + size,
+        0.0, std::plus<>()
+    );
+}
+
+} // namespace new_feature
+```
+
+Register in `src/bind.cpp`:
+```cpp
+m.def("compute", &new_feature::compute, "input"_a);
+```
+
+Reference `src/algorithms.cpp` (`dot1d`) as the canonical example of this pattern.
+
+## Pattern: Wrapping a Function with Python Callbacks
+
+For HPX functions that invoke Python callables, GIL management is critical:
+
+```cpp
+// In src/new_feature.cpp
+#include <nanobind/nanobind.h>
+#include <hpx/future.hpp>
+
+namespace nb = nanobind;
+
+namespace new_feature {
+
+hpx::future<nb::object> async_apply(nb::callable f, nb::args args) {
+    return hpx::async(
+        hpx::launch::deferred,
+        [f, args]() -> nb::object {
+            nb::gil_scoped_acquire acquire;  // MUST acquire GIL before calling Python
+            return f(*args);
+        });
+}
+
+} // namespace new_feature
+```
+
+Reference `src/futures.cpp` (`hpx_async`) as the canonical example.
+
+## Pattern: Binding an HPX Class (Template)
+
+For exposing HPX types like `hpx::future<T>`:
+
+```cpp
+template <typename T>
+void bind_hpx_type(nb::module_ &m, const char *name) {
+    nb::class_<hpx::some_type<T>>(m, name)
+        .def(nb::init<>())
+        .def("method", [](hpx::some_type<T> &self) {
+            // Lambda wrapper for complex methods
+            return self.method();
+        })
+        .def("method_with_callback", [](hpx::some_type<T> &self, nb::callable cb) {
+            nb::gil_scoped_acquire acquire;
+            return cb(self.get_value());
+        }, "callback"_a);
+}
+```
+
+Reference `src/bind.cpp` (`bind_hpx_future`) as the canonical example.
+
+## Pattern: Python Wrapper Layer
+
+Every C++ binding should have a corresponding Python wrapper in `src/hpyx/`:
+
+```python
+# src/hpyx/new_feature/_compute.py
+from __future__ import annotations
+
+from collections.abc import Callable
+from .._core import raw_function_name
+
+def compute(data, *, policy: str = "par") -> float:
+    """
+    High-level Python API with validation and docs.
+
+    Parameters
+    ----------
+    data : array-like
+        Input data array.
+    policy : str
+        Execution policy ("seq" or "par").
+    """
+    return raw_function_name(data, policy)
+```
+
+Key principles:
+- Import from `_core` (the compiled module)
+- Add type hints, docstrings, and parameter validation
+- Expose a Pythonic API (keyword arguments, sensible defaults)
+- Raise `NotImplementedError` for unimplemented policies rather than crashing
+
+## Nanobind Type Mappings
+
+| C++ Type | Nanobind Annotation | Python Type |
+|---|---|---|
+| `double` | automatic | `float` |
+| `int` / `std::size_t` | automatic | `int` |
+| `std::string` | `#include <nanobind/stl/string.h>` | `str` |
+| `std::vector<T>` | `#include <nanobind/stl/vector.h>` | `list` |
+| NumPy array | `nb::ndarray<nb::numpy, T, nb::c_contig>` | `numpy.ndarray` |
+| Python callable | `nb::callable` | `Callable` |
+| Python object | `nb::object` | `object` |
+| Variadic args | `nb::args` | `*args` |
+
+## CMake Integration
+
+When adding new source files, update `CMakeLists.txt`:
+
+```cmake
+nanobind_add_module(
+  _core
+  FREE_THREADED
+  src/bind.cpp
+  src/init_hpx.cpp
+  src/algorithms.cpp
+  src/futures.cpp
+  src/new_feature.cpp    # Add new source file here
+)
+```
+
+For new headers, create `src/new_feature.hpp` with the function declarations and include it in `src/bind.cpp`.
+
+## File Organization
+
+For the complete step-by-step scaffolding workflow and file checklist when adding a new binding, see the **add-binding** skill. The key files to create: C++ source + header in `src/`, register in `src/bind.cpp`, update `CMakeLists.txt`, Python wrapper in `src/hpyx/`, and tests in `tests/`.
+
+## Common Pitfalls
+
+- **Missing GIL acquire**: Any C++ lambda that calls Python (`nb::callable`, accessing `nb::object`) MUST use `nb::gil_scoped_acquire`
+- **Missing GIL release**: Long-running pure C++ operations should release the GIL with `nb::gil_scoped_release` to allow other Python threads to run
+- **Forgetting FREE_THREADED**: The `nanobind_add_module` call must include `FREE_THREADED` for Python 3.13 free-threading
+- **Moving futures**: `hpx::future` is move-only — use `std::move()` when capturing in lambdas
+- **Header includes**: Always include the specific HPX header, not the catch-all `<hpx/hpx.hpp>` (slower compilation)
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/nanobind-api.md`** — Nanobind API reference for common operations (ndarray, type casters, GIL management)

--- a/plugins/hpx-dev/skills/nanobind-patterns/references/nanobind-api.md
+++ b/plugins/hpx-dev/skills/nanobind-patterns/references/nanobind-api.md
@@ -1,0 +1,188 @@
+# Nanobind API Reference for HPyX
+
+Quick reference for Nanobind APIs commonly used in HPyX bindings.
+
+## Module Definition
+
+```cpp
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_core, m) {
+    m.doc() = "Module docstring";
+
+    // Function binding
+    m.def("func_name", &namespace::function, "arg1"_a, "arg2"_a,
+          "Docstring");
+
+    // Lambda binding
+    m.def("func_name", [](int x) { return x * 2; }, "x"_a);
+
+    // Module attribute
+    m.attr("__version__") = "1.0.0";
+}
+```
+
+## Type Bindings
+
+### Class Binding
+```cpp
+nb::class_<MyClass>(m, "MyClass")
+    .def(nb::init<>())                          // Default constructor
+    .def(nb::init<int, std::string>())          // Parameterized constructor
+    .def("method", &MyClass::method)            // Member function
+    .def("__repr__", &MyClass::to_string)       // Special method
+    .def_rw("field", &MyClass::field)           // Read-write property
+    .def_ro("const_field", &MyClass::const_field); // Read-only property
+```
+
+### Template Class Binding
+```cpp
+template <typename T>
+void bind_type(nb::module_ &m, const char *name) {
+    nb::class_<Container<T>>(m, name)
+        .def(nb::init<>())
+        .def("get", [](Container<T> &self) { return self.get(); })
+        .def("set", [](Container<T> &self, T val) { self.set(val); }, "val"_a);
+}
+
+// In NB_MODULE:
+bind_type<int>(m, "IntContainer");
+bind_type<double>(m, "DoubleContainer");
+```
+
+## STL Type Conversions
+
+```cpp
+#include <nanobind/stl/string.h>    // std::string ↔ str
+#include <nanobind/stl/vector.h>    // std::vector ↔ list
+#include <nanobind/stl/pair.h>      // std::pair ↔ tuple
+#include <nanobind/stl/tuple.h>     // std::tuple ↔ tuple
+#include <nanobind/stl/optional.h>  // std::optional ↔ Optional
+#include <nanobind/stl/map.h>       // std::map ↔ dict
+#include <nanobind/stl/set.h>       // std::set ↔ set
+```
+
+## NumPy ndarray
+
+```cpp
+#include <nanobind/ndarray.h>
+
+// Read-only double array, C-contiguous, NumPy
+nb::ndarray<nb::numpy, const double, nb::c_contig> arr;
+
+// Writable float array
+nb::ndarray<nb::numpy, float, nb::c_contig> arr;
+
+// Any dtype
+nb::ndarray<nb::numpy> arr;
+
+// Access data
+const double* data = arr.data();
+std::size_t size = arr.size();
+std::size_t ndim = arr.ndim();
+std::size_t shape_i = arr.shape(i);
+
+// With shape constraints
+nb::ndarray<nb::numpy, double, nb::shape<nb::any, 3>> matrix_nx3;
+```
+
+## Function Arguments
+
+```cpp
+// Named arguments
+m.def("func", &func, "x"_a, "y"_a);
+
+// Default values
+m.def("func", &func, "x"_a, "y"_a = 0);
+
+// Keyword-only
+m.def("func", &func, "x"_a, nb::kw_only(), "y"_a = 0);
+
+// Variadic args
+m.def("func", [](nb::args args) { /* ... */ }, nb::arg("*args"));
+
+// Callable
+m.def("func", [](nb::callable f) { f(); }, "f"_a);
+```
+
+## GIL Management
+
+```cpp
+// Acquire GIL (when in C++ thread, need to call Python)
+{
+    nb::gil_scoped_acquire acquire;
+    // Safe to call Python here
+    nb::object result = callback(arg);
+}
+
+// Release GIL (when in Python thread, doing pure C++ work)
+{
+    nb::gil_scoped_release release;
+    // Python threads can run while we do C++ work
+    expensive_cpp_computation();
+}
+```
+
+**HPyX-specific notes:**
+- With `FREE_THREADED` module flag, GIL operations become no-ops when GIL is disabled
+- Still include them for correctness — they protect against GIL-enabled Python builds
+- Thread safety must come from explicit synchronization (mutexes), not GIL
+
+## Python Object Manipulation
+
+```cpp
+// Create Python objects
+nb::object obj = nb::cast(42);
+nb::list lst;
+lst.append(nb::cast(1));
+
+// Call Python
+nb::callable func = ...;
+nb::object result = func(arg1, arg2);
+
+// Extract C++ value
+int value = nb::cast<int>(result);
+
+// Check type
+if (nb::isinstance<nb::int_>(obj)) { /* ... */ }
+
+// None
+nb::none();
+```
+
+## Error Handling
+
+```cpp
+// Raise Python exception from C++
+throw nb::value_error("message");
+throw nb::type_error("message");
+throw nb::index_error("message");
+throw nb::key_error("message");
+
+// Translate C++ exception to Python
+nb::register_exception_translator([](const std::exception_ptr &p, void *) {
+    try { std::rethrow_exception(p); }
+    catch (const MyException &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    }
+});
+```
+
+## FREE_THREADED Module Flag
+
+```cmake
+nanobind_add_module(
+  _core
+  FREE_THREADED    # Required for Python 3.13 free-threading
+  src/bind.cpp
+  ...
+)
+```
+
+This flag:
+- Marks the module as supporting free-threading
+- Enables per-object locking where needed
+- Makes GIL acquire/release no-ops when GIL is disabled
+- Must be set for all HPyX modules


### PR DESCRIPTION
## Summary
- Add project-level slash commands under `.claude/commands/` to standardize common git/release workflows.
- Add the `hpx-dev` plugin (`plugins/hpx-dev/`) with agents and skills tailored to HPX development, bindings, and benchmarking.

## Changes
- `.claude/commands/`: `clean-branches`, `commit`, `create-issue`, `create-pr`, `docs`, `merge-pr`, `push`, `release`.
- `plugins/hpx-dev/agents/`: `benchmark-engineer`, `binding-reviewer`, `hpx-api-explorer`.
- `plugins/hpx-dev/skills/`: `add-binding`, `benchmarking`, `build-system`, `gil-management`, `hpx-architecture`, `nanobind-patterns` (with supporting reference docs).
- Plugin manifest and README.

## Test plan
- [x] Verify slash commands load in Claude Code (e.g., `/commit`, `/create-pr`).
- [x] Verify the `hpx-dev` plugin manifest is valid and agents/skills are discoverable.
- [ ] Skim each skill/agent for accuracy against the current HPyX codebase.