### PR TITLE
docs(benchmarks): add v0 starting-point design spec

### DIFF
--- a/docs/design-docs/2026-04-24-benchmarking-v0-design.md
+++ b/docs/design-docs/2026-04-24-benchmarking-v0-design.md
@@ -1,0 +1,256 @@
+# Benchmarking & Profiling — v0 Starting Point
+
+**Project:** HPyX — Python bindings for HPX (nanobind)
+**Status:** Draft
+**Version:** 0.1
+**Last updated:** 2026-04-24
+**Companion doc:** `docs/design-docs/benchmarking_profiling_sdd.md` (full roadmap)
+
+---
+
+## 1. Purpose
+
+This document specifies a **minimal, trustworthy v0** of HPyX's benchmarking and
+profiling setup. It exists because today's `benchmarks/` directory has two
+ad-hoc files with measurement bugs, no shared fixtures, no profiling build, and
+no contract for how baselines are compared. Before we expand the Python API
+surface further, we need numbers we can trust.
+
+v0 is deliberately small. Everything beyond v0 — `pyperf`, `asv`, CI jobs, a
+dedicated physical runner, macro/memory suites, hard numeric targets — remains
+in the companion SDD as the forward roadmap. The SDD is not being deleted; it
+is being re-scoped so that this document is "Phase 0" and the existing phases
+become "Phase 1+".
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- **Fix what exists.** Rewrite the current `benchmarks/*.py` files so they
+  don't time runtime startup, don't measure Python dunder overhead instead of
+  HPX, and don't compare apples to oranges across files.
+- **Establish a contract** for how a benchmark is authored, so future additions
+  are consistent.
+- **Make local profiling reproducible.** Add a `profile` CMake preset and a
+  thin run-script so `py-spy`, `Scalene`, and `memray` work out of the box.
+- **Prove the free-threading axis** end-to-end with one smoke benchmark, so we
+  know the harness will hold when we expand it.
+
+### Non-Goals
+
+- No CI integration in v0. (`bench-smoke` / `bench-full` remain in the SDD.)
+- No `pyperf`, no `asv`, no dashboard, no dedicated physical runner.
+- No `TARGETS.md` with hard numeric budgets. Targets are earned by measurement,
+  not asserted up front.
+- No macro or memory suites. v0 is microbenchmarks only.
+
+## 3. Scope Summary (what v0 ships)
+
+1. Align on the `benchmarks/` directory name (matches what's on disk today).
+   The SDD is updated to use `benchmarks/` instead of `bench/`.
+2. Rewrite the two existing benchmark files to follow the authoring contract
+   (Section 5).
+3. Add `benchmarks/conftest.py` with shared fixtures (Section 6).
+4. Add baselines: **NumPy**, **pure Python**, and
+   **`concurrent.futures.ThreadPoolExecutor`** — wired into every HPyX
+   microbenchmark through the contract.
+5. Add a `profile` CMake preset (Section 7).
+6. Add **one** free-threading smoke benchmark for `for_loop`, gated on a
+   3.13t interpreter (Section 6, fixture `requires_free_threading`).
+7. Add `scripts/run_bench_local.sh` wrapping the common flows.
+8. Add `benchmarks/README.md` — a ~one-page contributor doc covering how to
+   run, how to add, and how to profile locally.
+9. Update the companion SDD to (a) use `benchmarks/`, (b) add Python 3.13
+   free-threading as a first-class axis in authoring conventions and risks,
+   and (c) mark this document as "Phase 0 / starting point".
+
+## 4. Directory Layout After v0
+
+```
+benchmarks/
+├── conftest.py                      # shared fixtures (Section 6)
+├── README.md                        # contributor doc (Section 8)
+├── test_bench_for_loop.py           # rewritten against contract
+├── test_bench_hpx_linalg.py         # rewritten against contract
+├── test_bench_thread_scaling.py     # new: varies HPX thread count
+└── test_bench_free_threading.py     # new: one smoke test, gated on 3.13t
+
+scripts/
+└── run_bench_local.sh               # new: pytest-benchmark + py-spy wrapper
+
+CMakePresets.json                    # adds `profile` preset
+docs/design-docs/
+├── benchmarking_profiling_sdd.md    # updated (see Section 9)
+└── 2026-04-24-benchmarking-v0-design.md   # this doc
+```
+
+## 5. Benchmark Authoring Contract
+
+Every benchmark file in v0 follows these rules. This contract is the load-
+bearing part of v0 — the fixtures and preset exist to make it enforceable.
+
+1. **Setup is never timed.** Runtime startup, array allocation, RNG — all
+   outside the timed region. Use `benchmark.pedantic(fn, setup=..., rounds=...,
+   iterations=...)` when the default fixture isn't enough. The current
+   `test_bench_for_loop.py` violates this by putting `HPXRuntime()` inside the
+   timed callable; the rewrite fixes it via the session-scoped `hpx_runtime`
+   fixture.
+
+2. **Parametrize on size across three orders of magnitude.** Minimum sizes
+   `[1_000, 100_000, 10_000_000]` so fixed call overhead is separable from
+   per-element cost visually.
+
+3. **Every HPyX benchmark has matching baselines in the same group.** For a
+   benchmark measuring `hpyx.for_loop` applied to operation `f`, we also
+   measure the NumPy, pure-Python, and `concurrent.futures.ThreadPoolExecutor`
+   equivalents of `f` at the same sizes and in the same `pytest-benchmark`
+   group. Absence of a meaningful baseline (e.g. no NumPy equivalent exists)
+   must be documented in the test's docstring.
+
+4. **Group names are explicit.** Each file declares
+   `pytestmark = pytest.mark.benchmark(group="<topic>")` at module scope. One
+   group per "thing being compared" — not one group per file.
+
+5. **Payloads minimize Python overhead unless Python overhead is the point.**
+   Avoid patterns like `result.__setitem__(i, arr[i] ** 2)` in the hot path
+   when a C-level equivalent is available through the binding. Where a Python
+   callback is intrinsic to the binding's design (e.g. `for_loop` with a
+   Python lambda), the benchmark's docstring must state that the measurement
+   includes callback overhead, so readers don't misread the result.
+
+6. **Thread-scaling benchmarks parametrize on thread count.**
+   `@pytest.mark.parametrize("threads", [1, 2, 4, 8])`, configured via the
+   `hpx_threads` fixture. Tests are skipped when the host has fewer physical
+   cores than the requested thread count.
+
+7. **Free-threading benchmarks gate on interpreter state.** Any benchmark
+   that asserts speedup under nogil uses the `requires_free_threading` fixture
+   (checks `sysconfig.get_config_var("Py_GIL_DISABLED")`). In v0 this applies
+   to exactly one test: a thread-scaling smoke test for `for_loop`.
+
+## 6. Shared Fixtures (`benchmarks/conftest.py`)
+
+| Fixture | Scope | Purpose |
+|---|---|---|
+| `pin_cpu` | session, autouse | `os.sched_setaffinity(0, {0})` on Linux; no-op on macOS (documented as noisier). |
+| `seed_rng` | function, autouse | Deterministically seeds `random`, `numpy.random`, and any HPyX RNG from the test id. |
+| `no_gc` | function, opt-in | Context-manager fixture that disables `gc` during the timed region. Opt-in per benchmark. |
+| `hpx_runtime` | session | Starts `HPXRuntime()` once per session; tears down at exit. Benchmarks reuse instead of start/stop per call. |
+| `hpx_threads` | function, indirect | Parametrizes HPX thread count. Used only by `test_bench_thread_scaling.py` and `test_bench_free_threading.py` — see resolution in Section 6.1. |
+| `requires_free_threading` | marker + skip | Skips test unless `sysconfig.get_config_var("Py_GIL_DISABLED") == 1`. |
+| `env_sanity_check` | session, autouse | Fails on battery power (Linux); fails if HPX was built in Debug mode; warns if turbo-boost state cannot be determined. |
+
+### 6.1 Thread-count vs. session runtime — resolution
+
+A session-scoped `hpx_runtime` conflicts with benchmarks that need to vary
+thread count. Resolution: **thread-count-varying benchmarks live in dedicated
+files** (`test_bench_thread_scaling.py`, `test_bench_free_threading.py`) and
+use a file-local, function-scoped runtime that restarts per parametrization.
+All other benchmarks use the session-scoped `hpx_runtime` fixture. This keeps
+the fast path fast and the slow path explicit.
+
+## 7. `profile` CMake Preset
+
+Matches release-level optimization so numbers are meaningful, differing only
+in debug info, frame pointers, and LTO so `py-spy --native`, `perf`, and
+`memray --native` can resolve C++ frames.
+
+```json
+{
+  "name": "profile",
+  "inherits": "release",
+  "cacheVariables": {
+    "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+    "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -fno-omit-frame-pointer",
+    "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF",
+    "CMAKE_CXX_VISIBILITY_PRESET": "default"
+  }
+}
+```
+
+Actual wiring follows the `hpx-dev:build-system` skill's conventions for this
+repo.
+
+## 8. `scripts/run_bench_local.sh` and Contributor README
+
+### 8.1 `scripts/run_bench_local.sh`
+
+Thin wrapper exposing three subcommands:
+
+- `bench [pytest args]` — runs `pytest benchmarks/ --benchmark-only` with
+  repo defaults (e.g. `--benchmark-min-rounds=5`).
+- `record <test-id>` — runs the selected benchmark under
+  `py-spy record --native --rate 500 -o flame.svg -- …`.
+- `compare` — runs `pytest-benchmark compare` against the locally stored
+  baseline.
+
+The script does not install tooling; it assumes `py-spy` is on `PATH` and
+falls back with an actionable error message otherwise.
+
+### 8.2 `benchmarks/README.md`
+
+Three sections, ~one page total:
+
+1. **How to run.** `pixi run bench`, how to filter (`-k`), how to save and
+   compare a baseline with `pytest-benchmark`.
+2. **How to add a benchmark.** Inlines the 7-rule contract from Section 5
+   with one worked example (the rewritten `for_loop` square benchmark).
+3. **How to profile locally.** One copy-pasteable command each for `py-spy`
+   (cross-language flame graph), `Scalene` (per-line Python vs. native),
+   `memray` (allocation flame graph). Prerequisite note: build with the
+   `profile` preset.
+
+Everything else — `pyperf` usage, `asv` dashboard, CI behavior, regression
+thresholds — is deferred to the companion SDD and linked from the README.
+
+## 9. Changes to the Companion SDD
+
+The existing `benchmarking_profiling_sdd.md` is updated, not replaced:
+
+1. All `bench/` references changed to `benchmarks/` to match reality.
+2. Section 6 ("Benchmark Suite Design") and Section 10 ("Metrics and Targets")
+   gain **Python 3.13 free-threading as a first-class axis**: thread-scaling
+   speedup targets are stated under both GIL and nogil interpreters, and the
+   authoring conventions reference the `requires_free_threading` fixture.
+3. Section 12 ("Risks and Mitigations") adds a row for "free-threading
+   interpreter availability in CI".
+4. Section 13 ("Rollout Plan") is prefixed with a new "Phase 0 — Starting
+   point" entry pointing at this document; the existing Phases 1–5 are
+   renumbered as Phases 1–5 of the expansion from Phase 0.
+
+## 10. Acceptance Criteria
+
+v0 is done when all of the following are true:
+
+- `benchmarks/conftest.py` exists with the seven fixtures in Section 6.
+- The two existing benchmark files are rewritten to follow Section 5's
+  contract, and each HPyX microbenchmark has NumPy, pure-Python, and
+  `concurrent.futures.ThreadPoolExecutor` baselines in the same group.
+- `test_bench_thread_scaling.py` exists and runs on the default interpreter.
+- `test_bench_free_threading.py` exists, passes under a 3.13t interpreter,
+  and skips cleanly under standard CPython 3.13.
+- `CMakePresets.json` has a `profile` preset and a `profile`-preset build
+  produces an extension with resolvable C++ frames under `py-spy dump`.
+- `scripts/run_bench_local.sh` runs the three subcommands end-to-end on a
+  developer machine.
+- `benchmarks/README.md` is written and links to the companion SDD.
+- The companion SDD reflects the changes in Section 9.
+
+## 11. Risks and Mitigations (v0-specific)
+
+| Risk | Mitigation |
+|---|---|
+| Session-scoped `hpx_runtime` hides per-call startup regressions. | A dedicated micro-benchmark (in a file that opts out of the `hpx_runtime` session fixture) measures cold `HPXRuntime()` start/stop explicitly. Exact file location decided during implementation. |
+| `concurrent.futures` baseline is misleading for CPU-bound work under the GIL. | Baselines are labeled; the benchmark docstring calls out that `ThreadPoolExecutor` on GIL CPython is a ceiling on what naive users reach for, not a fair parallel comparison. |
+| Free-threading smoke test provides false confidence. | Scope is explicit: "the harness works end-to-end," not "HPyX scales linearly." No performance claims derived from v0. |
+| macOS noise invalidates comparisons. | Documented in README; `pin_cpu` is a no-op on macOS; developer loop remains usable, but "authoritative" numbers are Linux-only (consistent with the SDD). |
+
+## 12. Out of Scope (tracked in companion SDD)
+
+- `pyperf` multi-process isolation runs for published numbers.
+- `asv` continuous tracking and HTML dashboard.
+- `bench-smoke` and `bench-full` GitHub Actions workflows.
+- Dedicated physical runner, `pyperf system tune`.
+- Macro/end-to-end and memory-shape suites.
+- `memray` and `py-spy` artifact uploads on tagged releases.
+- `TARGETS.md` numeric budgets.

--- a/docs/design-docs/benchmarking_profiling_sdd.md
+++ b/docs/design-docs/benchmarking_profiling_sdd.md
@@ -1,0 +1,262 @@
+# Software Design Document: Benchmarking & Profiling Infrastructure
+
+**Project:** Python Bindings (nanobind) — Performance Measurement Subsystem
+**Status:** Draft
+**Version:** 0.1
+**Last updated:** 2026-04-24
+
+---
+
+## 1. Purpose
+
+This document describes the design of a benchmarking and profiling subsystem for a Python binding built on top of a C++ library using **nanobind**. The subsystem is responsible for:
+
+1. Measuring the performance of the Python-facing API under representative workloads.
+2. Detecting regressions automatically as the C++ library and the binding layer evolve.
+3. Providing actionable insight into *where* time is spent across the Python / nanobind / C++ boundary.
+4. Producing comparable, reproducible numbers suitable for release notes and public claims.
+
+Performance of the underlying C++ algorithms is out of scope except where it interacts with binding design (e.g. GIL handling, copy vs. view semantics, batching).
+
+## 2. Scope
+
+**In scope**
+
+- Microbenchmarks for individual binding entry points.
+- Macro / end-to-end benchmarks simulating realistic user workloads.
+- Cross-language profiling (Python + native C++ stacks unified).
+- Memory profiling, including allocations that cross the language boundary.
+- Continuous performance tracking over time on a dedicated runner.
+- Developer-facing tooling for local investigation.
+
+**Out of scope**
+
+- Correctness testing (covered by the existing `pytest` test suite).
+- Profiling of pure-C++ code paths that are not reachable from Python.
+- GPU profiling (unless bindings are explicitly added for GPU paths).
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- **Reproducibility.** Any contributor can run the benchmark suite locally and get results within ~5% of the CI numbers.
+- **Regression detection.** A regression >5% in any tracked benchmark should fail CI, or at minimum produce a visible alert.
+- **Boundary visibility.** For every hot binding call, we can attribute time to (a) Python interpreter overhead, (b) nanobind marshalling, and (c) native C++ work.
+- **Low friction.** Writing a new benchmark should be as easy as writing a `pytest` test.
+- **Longitudinal data.** Performance history is retained per-commit and browsable via a web dashboard.
+
+### Non-Goals
+
+- Replacing the functional test suite.
+- Benchmarking third-party Python code that merely uses our library.
+- Perfect statistical parity across different hardware — we compare within a host, not across hosts.
+
+## 4. System Context
+
+```
+            ┌────────────────────────┐
+   user  ─► │   Python API surface   │  (pure-Python wrappers, if any)
+            └────────────┬───────────┘
+                         │
+            ┌────────────▼───────────┐
+            │ nanobind binding layer │  ← allocations, type conversions,
+            └────────────┬───────────┘    GIL release/acquire
+                         │
+            ┌────────────▼───────────┐
+            │  C++ core library      │  ← algorithms under test
+            └────────────────────────┘
+```
+
+The subsystem instruments the top three layers. The C++ core is treated as a black box here, but the profilers we use can descend into it when their stacks are resolvable.
+
+## 5. Toolchain
+
+### 5.1 Benchmarking
+
+| Tool | Role | Rationale |
+|---|---|---|
+| `pytest-benchmark` | Primary microbenchmark harness | Low barrier; discovers benchmarks like tests; produces JSON artifacts. |
+| `pyperf` | Statistically rigorous runs for "published" numbers | Multi-process isolation, warmup, system tuning (`pyperf system tune`). |
+| `asv` (airspeed velocity) | Longitudinal tracking across commits | Produces a browsable HTML dashboard; used by NumPy/SciPy/pandas. |
+
+### 5.2 Profiling
+
+| Tool | Role | Rationale |
+|---|---|---|
+| `py-spy --native` | Unified Python + C++ sampling flame graphs | Attaches to running processes; no code changes; resolves both stacks. |
+| `Scalene` | Per-line split of Python vs. native time, CPU, memory, GPU | Fastest way to find where nanobind overhead or C++ work dominates. |
+| `memray --native` | Memory allocations with native stacks | Detects leaks and churn caused by the binding layer. |
+| `perf` + FlameGraph | Deep-dive on C++ hotspots identified above | Lower-level, kernel-aware; Linux only. |
+| `callgrind` / KCachegrind | Instruction-level analysis when needed | Slow but exact; useful for verifying optimization theories. |
+
+### 5.3 Build configuration for profiling
+
+C++ code must be built with:
+
+- `-O2` (release-like optimization) **and** `-g` (debug info) **and** `-fno-omit-frame-pointer`.
+- Symbol visibility preserved (`-fvisibility=default` for the extension module or explicit `NB_MODULE` exports).
+- Link-time optimization disabled for profiling builds (it collapses frames py-spy needs).
+
+A dedicated CMake preset `profile` produces this configuration so profiling builds do not interfere with release builds.
+
+## 6. Benchmark Suite Design
+
+### 6.1 Directory layout
+
+```
+bench/
+├── conftest.py              # shared fixtures: warm caches, pin CPU, seed RNG
+├── micro/
+│   ├── test_call_overhead.py   # no-op calls, argument conversion costs
+│   ├── test_array_ingest.py    # numpy/buffer → C++ paths
+│   ├── test_return_paths.py    # C++ → Python object construction
+│   └── test_gil.py             # threaded calls with/without GIL release
+├── macro/
+│   ├── test_pipeline_small.py
+│   ├── test_pipeline_large.py
+│   └── test_realistic_workload.py
+├── memory/
+│   └── test_allocation_shape.py
+└── asv_bench/                # mirror of above adapted for asv
+    ├── benchmarks.py
+    └── asv.conf.json
+```
+
+### 6.2 Categories of benchmark
+
+1. **Call-overhead microbenchmarks.** Measure the floor cost of invoking a binding: no-op functions, trivial returns, per-argument-type overhead. These catch regressions in nanobind itself or in how we're using it.
+2. **Data-ingest microbenchmarks.** Measure `numpy.ndarray`, `bytes`, `str`, `list`, and custom-type conversion on the way in. Vary sizes (1, 1K, 1M elements) to separate fixed cost from per-element cost.
+3. **Return-path microbenchmarks.** Measure object construction, buffer protocol, and ownership transfer on the way out.
+4. **GIL behavior.** Confirm long C++ calls release the GIL and scale with threads. Benchmark both with-GIL and without-GIL variants.
+5. **End-to-end workloads.** A small number of representative pipelines drawn from real users, sized to run in seconds, not minutes.
+6. **Memory shape.** Peak RSS, allocation count, and allocation sizes for each macro benchmark.
+
+### 6.3 Authoring conventions
+
+- Every benchmark is parametrized on input size to separate O(1) from O(n) costs.
+- Every benchmark has a companion "baseline" — either the previous implementation, a pure-Python equivalent, or a direct `ctypes` call — to give numbers meaning.
+- Setup is never timed. Use `pytest-benchmark`'s `benchmark.pedantic()` when fine control is needed.
+- Each file declares a `pytestmark = pytest.mark.benchmark(group="…")` so results cluster sensibly in the report.
+
+### 6.4 Environment controls
+
+A `conftest.py` fixture:
+
+- Pins the process to a single CPU (`os.sched_setaffinity`) on Linux.
+- Disables Python's GC during timed regions where appropriate.
+- Seeds all RNGs deterministically.
+- Fails loudly if the machine is on battery, has turbo boost enabled, or is running a debug build.
+
+## 7. Profiling Workflow
+
+### 7.1 Developer local loop
+
+1. Build with the `profile` CMake preset.
+2. Run the target benchmark under py-spy:
+   ```
+   py-spy record --native --rate 500 -o flame.svg -- \
+       pytest bench/macro/test_pipeline_small.py -k large
+   ```
+3. Open `flame.svg`; identify hot frames.
+4. For Python-side detail: re-run under Scalene.
+   ```
+   scalene --cli --profile-all bench/macro/test_pipeline_small.py
+   ```
+5. For memory: `memray run --native … && memray flamegraph …`.
+6. Iterate.
+
+### 7.2 CI profiling artifacts
+
+On every tagged release candidate, CI runs py-spy and memray over the macro suite and uploads the SVG flame graphs as build artifacts, so reviewers can inspect without reproducing locally.
+
+## 8. Continuous Tracking (asv)
+
+- A dedicated, consistent physical runner (same hardware, same OS image) runs `asv run` nightly against `main` and on every merge.
+- Results are published to a static site (e.g. GitHub Pages) under `/perf/`.
+- `asv continuous HEAD~1 HEAD` runs on every PR touching code in `src/` or `bench/`, posting a summary comment.
+- A configurable regression threshold (default 5%) marks PR runs as failed.
+- Historical JSON is kept in a separate long-lived repository so dashboard rebuilds are cheap.
+
+## 9. CI Integration
+
+Two jobs, both on the dedicated runner:
+
+**`bench-smoke`** — runs on every PR.
+- Builds with `profile` preset.
+- Runs the `micro/` suite under `pytest-benchmark` with `--benchmark-min-rounds=5`.
+- Compares against the baseline stored for `main` using `pytest-benchmark compare`.
+- Fails if any benchmark regresses by more than the configured threshold.
+- Target wall-clock: under 5 minutes.
+
+**`bench-full`** — runs nightly and on release tags.
+- Runs micro + macro + memory suites.
+- Runs `asv run` and publishes the dashboard.
+- Uploads py-spy and memray artifacts for macro benchmarks.
+- Target wall-clock: under 45 minutes.
+
+## 10. Metrics and Targets
+
+Initial targets (to be tuned once the first runs land):
+
+| Metric | Target |
+|---|---|
+| No-op binding call overhead | < 150 ns median |
+| 1M-float numpy ingest | < 2 µs fixed + < 1 ns/element |
+| GIL-released C++ call, 8 threads | > 6× speedup vs. single thread |
+| Macro pipeline "small" | < 200 ms median, < 5% p99/median spread |
+| Peak RSS for macro pipeline "large" | < 1.5× C++-only equivalent |
+| Allocation count per macro run | Within 10% of previous release |
+
+These are tracked in `bench/TARGETS.md` and reviewed each release.
+
+## 11. Directory & File Inventory (new)
+
+```
+bench/                          # new
+CMakePresets.json               # add `profile` preset
+.github/workflows/bench.yml     # new
+docs/perf/                      # new, human-readable performance notes
+scripts/
+  run_bench_local.sh            # thin wrapper around common flows
+  compare_against_main.sh
+bench/TARGETS.md                # performance budgets
+```
+
+## 12. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Noisy CI results cause false regressions. | Dedicated physical runner; `pyperf system tune`; multiple rounds; median-based comparison; generous initial thresholds, tightened over time. |
+| Profiling build diverges from release build, misleading results. | `profile` preset differs only in `-g` and frame pointers; LTO and optimization level match release. |
+| Binding design locked in by benchmarks (premature optimization). | Benchmarks measure outcomes, not implementation; refactors are fine as long as budgets hold. |
+| Long nightly runs block the runner. | Macro suite is size-bounded; cap total wall-clock at 45 min; split into sharded jobs if exceeded. |
+| Symbol resolution fails for C++ frames in py-spy. | CI step verifies `py-spy dump` against a running benchmark shows resolved C++ frames; build fails otherwise. |
+
+## 13. Rollout Plan
+
+1. **Phase 1 — Skeleton.** Land `bench/` directory, `conftest.py`, three illustrative microbenchmarks, `profile` CMake preset, local run script. No CI yet. *(≈1 week)*
+2. **Phase 2 — Smoke CI.** Add `bench-smoke` job; establish baseline on `main`; tune thresholds against a week of noise data. *(≈1 week)*
+3. **Phase 3 — Macro + memory.** Add macro and memory suites; wire memray/py-spy artifact uploads on nightly. *(≈2 weeks)*
+4. **Phase 4 — asv dashboard.** Stand up the dedicated runner, publish the dashboard, add PR continuous comparisons. *(≈2 weeks)*
+5. **Phase 5 — Harden.** Tighten thresholds, document the workflow in `docs/perf/`, write a contributor guide for adding benchmarks. *(ongoing)*
+
+## 14. Open Questions
+
+- Which physical machine hosts the asv runner? (Needs owner + access policy.)
+- Do we publish performance numbers externally with each release, or keep them internal for now?
+- Should we add a Windows and/or macOS benchmark job, or Linux-only for v1?
+- What is the authoritative baseline commit for the first release — the last tagged release or the state of `main` at Phase 2 completion?
+
+## 15. References
+
+- nanobind documentation — https://nanobind.readthedocs.io/
+- pytest-benchmark — https://pytest-benchmark.readthedocs.io/
+- pyperf — https://pyperf.readthedocs.io/
+- asv (airspeed velocity) — https://asv.readthedocs.io/
+- py-spy — https://github.com/benfred/py-spy
+- Scalene — https://github.com/plasma-umass/scalene
+- memray — https://github.com/bloomberg/memray
+
+---
+
+*Appendix A: example `conftest.py`, example `asv.conf.json`, and a reference `bench-smoke` GitHub Actions workflow — to be added in Phase 1.*


### PR DESCRIPTION
## Summary
- Adds a new design document scoping a minimal, trustworthy **v0** for the HPyX benchmarking and profiling subsystem, before the Python API surface expands further.
- Complements (does not replace) the existing `benchmarking_profiling_sdd.md`, which remains the long-term roadmap. This spec explicitly defers `pyperf`, `asv`, CI jobs, macro/memory suites, and numeric targets to that companion doc.

## Changes
- New: `docs/design-docs/2026-04-24-benchmarking-v0-design.md`
  - Section 5: 7-rule benchmark authoring contract (no timed setup, 3-order-of-magnitude size sweep, required NumPy + pure-Python + `concurrent.futures` baselines in the same group, explicit group names, minimize incidental Python overhead, thread-scaling parametrization, free-threading gating).
  - Section 6: shared `benchmarks/conftest.py` fixtures (`pin_cpu`, `seed_rng`, `no_gc`, `hpx_runtime`, `hpx_threads`, `requires_free_threading`, `env_sanity_check`) with an explicit resolution for the session-runtime vs. thread-count conflict.
  - Section 7: `profile` CMake preset (RelWithDebInfo + `-fno-omit-frame-pointer`, LTO off, default visibility) so `py-spy --native`, `perf`, and `memray --native` can resolve C++ frames.
  - Section 8: `scripts/run_bench_local.sh` subcommands and a one-page contributor `benchmarks/README.md`.
  - Section 9: planned updates to the companion SDD (directory rename `bench/` → `benchmarks/`, elevate Python 3.13 free-threading to a first-class axis, prepend "Phase 0" to the rollout plan).
  - Section 10: acceptance criteria for v0.

## Test plan
- [x] Reviewer confirms v0 scope is small enough to land in a single implementation plan.
- [x] Reviewer agrees with the session-scoped `hpx_runtime` fixture + dedicated file for thread-count-varying benchmarks (Section 6.1).
- [x] Reviewer agrees that `concurrent.futures.ThreadPoolExecutor` is the right third baseline alongside NumPy + pure Python.
- [x] Reviewer agrees with deferring `pyperf`/`asv`/CI/macro/memory/`TARGETS.md` to the existing SDD (Section 12).
- [x] No follow-up edits block moving to an implementation plan via the writing-plans workflow.