### PR TITLE
docs(usage): update v1 runtime API docs and add architecture decisions

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,5 +2,6 @@ nav:
   - Overview:
       - Welcome to HPyX Documentation: index.md
       - Usage Guide: usage.md
+      - Architecture Decisions: architecture-decisions.md
   - API Reference: reference/api.md
   - Contributing: CONTRIBUTING.md

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1,0 +1,61 @@
+# Architecture Decisions
+
+A running log of significant architecture decisions made during HPyX development. Entries are listed newest-first within each phase.
+
+---
+
+## Phase 0 — Foundation (2026-04-24)
+
+### 2026-04-24: Move C++ sources into `src/_core/` package (Implemented)
+
+- **Decision:** Move all flat `src/*.cpp` / `src/*.hpp` files into `src/_core/` and rename `init_hpx.*` → `runtime.*`.
+- **Why:** The old flat layout put `bind.cpp`, `init_hpx.cpp`, `algorithms.cpp`, and `futures.cpp` all in the same directory as the Python `hpyx/` package, with no structural separation between the top-level module glue and the implementation units. As HPyX grows to cover futures, parallel algorithms, and kernels, each gets its own `.cpp` file under `_core/`. The new layout gives nanobind a clean home (`src/_core/`) and makes it obvious that everything under `_core/` is compiled C++ while `src/hpyx/` is pure Python.
+- **Result:** `CMakeLists.txt` updated to reference `src/_core/*.cpp`. No behavior change — 62 existing tests pass unchanged. `init_hpx.cpp` renamed `runtime.cpp` to match its actual responsibility.
+
+### 2026-04-24: Expose runtime API as `_core.runtime` submodule (Implemented)
+
+- **Decision:** Register the HPX runtime bindings on a `_core.runtime` submodule (via `register_bindings(nb::module_&)`) rather than directly on `_core`.
+- **Why:** HPyX v1 will expose `_core.futures`, `_core.parallel`, and `_core.kernels` as separate submodules. Keeping runtime on the top-level `_core` namespace would mean future calls like `_core.runtime_start()` sit alongside `_core.dot1d()`, which is confusing. Moving them to `_core.runtime.*` now avoids a breaking rename later.
+- **Result:** `_core.runtime_start`, `_core.stop_hpx_runtime`, etc. are removed from the top-level namespace. Replaced by `_core.runtime.runtime_start`, `_core.runtime.runtime_stop`, `_core.runtime.runtime_is_running`, `_core.runtime.num_worker_threads`, `_core.runtime.get_worker_thread_id`, `_core.runtime.hpx_version_string`. Callers in `print_versions.py` updated.
+
+### 2026-04-24: Release GIL during `hpx::start` construction (Implemented)
+
+- **Decision:** `runtime_start` releases the GIL (`nb::gil_scoped_release`) around the `new global_runtime_manager(cfg)` call instead of holding it.
+- **Why:** The original `init_hpx_runtime` held a `nb::gil_scoped_acquire` around runtime construction. Under GIL-mode Python this was harmless but redundant. Under **free-threaded Python 3.13t** it is a bug: `hpx::start` spawns OS threads that eventually call Python-side callbacks; if the GIL is held during the blocking startup CV wait, any new thread that tries to acquire the GIL deadlocks. The fix is to release the GIL before calling `hpx::start` so worker threads can proceed.
+- **Result:** `runtime_start` correctly supports both GIL-mode and free-threaded builds. Smoke-tested with `sysconfig.get_config_var("Py_GIL_DISABLED") == 1` on Python 3.13t.
+
+### 2026-04-24: `g_stopped` flag prevents in-process restart (Implemented)
+
+- **Decision:** Add an `std::atomic<bool> g_stopped` flag that is set to `true` on `runtime_stop` and causes `runtime_start` to throw `RuntimeError` on any subsequent call.
+- **Why:** HPX explicitly prohibits restarting the runtime within the same process (it uses process-global singletons for the scheduler, AGAS, etc.). Without this flag, calling `_core.runtime.runtime_start()` after a stop would silently fail or crash. The flag surfaces the constraint as a clear Python exception.
+- **Result:** `RuntimeError: HPyX runtime has been stopped and cannot restart within this process` is raised on any restart attempt. Tested in `tests/test_runtime.py::test_shutdown_makes_further_init_raise`.
+
+### 2026-04-24: `hpyx._runtime` as the single auto-init authority (Implemented)
+
+- **Decision:** All public Python APIs that need the HPX runtime call `hpyx._runtime.ensure_started()` rather than calling `_core.runtime.runtime_start()` directly.
+- **Why:** Without a central authority, every public function would need to independently manage the "has it started yet?" check, the env-var config merge, the conflicting-config error, and the `atexit` registration. That logic would be duplicated across `hpyx.futures`, `hpyx.parallel`, `hpyx.debug`, etc. `_runtime.ensure_started()` is the single place where the lifecycle invariants are enforced.
+- **Result:** `hpyx.debug`, `hpyx.runtime.HPXRuntime`, and `hpyx.__init__.init` all delegate to `_runtime.ensure_started()`. The `threading.Lock` in `_runtime` makes it safe for concurrent callers on free-threaded 3.13t.
+
+### 2026-04-24: `atexit` owns HPX shutdown (Implemented)
+
+- **Decision:** `_runtime.ensure_started()` registers `_atexit_shutdown` with Python's `atexit` module on first start. `HPXRuntime.__exit__` is a no-op. There is no automatic teardown at the end of a `with HPXRuntime():` block.
+- **Why:** In v0.x, `HPXRuntime.__exit__` called `_core.stop_hpx_runtime()`. This caused two problems: (1) after the context manager exited, any subsequent HPyX call in the same process would fail because HPX can't restart; (2) users writing scripts with multiple `with HPXRuntime():` blocks got silent failures. The atexit approach means the runtime lives for the entire process lifetime — which matches what users actually want 99% of the time.
+- **Result:** `HPXRuntime.__exit__` returns `None`. Process cleanup happens via `atexit`. Users who need early shutdown call `hpyx.shutdown()` explicitly and understand the restart constraint.
+
+### 2026-04-24: `CMakePresets.json` with `profile` preset for native profiling (Implemented)
+
+- **Decision:** Add a `profile` preset with `RelWithDebInfo` + `-fno-omit-frame-pointer` + IPO off.
+- **Why:** `py-spy --native`, `perf`, and `memray --native` all require C++ frames to be resolvable in the symbol table. A default Release build omits frame pointers (compiler optimization) and enables IPO (inlines away call boundaries), making profiler output unreadable for C++ code. The `profile` preset keeps optimization level (`-O2`) while trading a small performance overhead for reliable frame resolution.
+- **Result:** `cmake --preset profile` produces a build suitable for `py-spy record --native -- python my_benchmark.py`. Used by `scripts/run_bench_local.sh` (lands in Plan 4).
+
+### 2026-04-24: `hpyx.config` as pure-Python env-var parser (Implemented)
+
+- **Decision:** `hpyx.config` is a pure-Python module (`from_env()` + `DEFAULTS`), not a C++ binding.
+- **Why:** Config values are only needed at Python startup time (before the first `_core.runtime.runtime_start` call). There is no need for C++ to know about `HPYX_OS_THREADS` — Python builds the HPX config strings and passes them as a `list[str]`. Keeping the config layer in Python makes it easy to test with `monkeypatch`, import without a compiled extension, and extend without touching C++.
+- **Result:** `tests/test_config.py` has 15 pure-Python tests with no build dependency. Env-var precedence is validated with `monkeypatch`.
+
+### 2026-04-24: `hpyx.debug.enable_tracing` stubbed in Phase 0 (Implemented)
+
+- **Decision:** `enable_tracing` and `disable_tracing` raise `NotImplementedError("ships in v1.x (Plan 4)")` rather than being absent from the public API.
+- **Why:** Advertising the tracing surface in Phase 0 stabilizes the public API shape so documentation and user code can reference `hpyx.debug.enable_tracing(path)` consistently. The stub prevents silent `AttributeError`s if someone tries to use it early and gives a clear error message explaining when it ships.
+- **Result:** `hpyx.debug` is importable and documented from Phase 0 onward. Full JSONL-output implementation deferred to Plan 4.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,25 +15,28 @@ HPyX is a high-performance Python library providing bindings to the HPX C++ runt
 
 ## Getting Started
 
-HPyX provides:
-
-- `HPXRuntime`: Context manager for HPX runtime lifecycle
-- `hpyx.futures.submit`: Submit functions for asynchronous execution
-- `hpyx.multiprocessing.for_loop`: Parallel iteration over collections
-
-**Example:**
+HPyX v1 auto-initializes the HPX runtime on first use — no setup boilerplate required:
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 from hpyx.multiprocessing import for_loop
 
-with HPXRuntime():
-	future = submit(lambda x: x * x, 5)
-	print(future.get())
-	data = [1, 2, 3]
-	for_loop(lambda x: x + 1, data, "seq")
-	print(data)
+# Submit work asynchronously — runtime starts automatically
+future = submit(lambda x: x * x, 5)
+print(future.get())  # 25
+
+# Parallel iteration
+data = [1, 2, 3]
+for_loop(lambda x: x + 1, data, "seq")
+print(data)  # [2, 3, 4]
+```
+
+To control thread count or configuration explicitly:
+
+```python
+import hpyx
+
+hpyx.init(os_threads=8)  # or set HPYX_OS_THREADS=8 in the environment
 ```
 
 For more details, see the [Usage Guide](usage.md).
@@ -43,6 +46,12 @@ For more details, see the [Usage Guide](usage.md).
 ## API Reference
 
 Full API documentation is available in the [API Reference](reference/api.md).
+
+---
+
+## Architecture Decisions
+
+Significant design choices and their rationale are recorded in the [Architecture Decisions](architecture-decisions.md) log.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,79 +2,194 @@
 
 This guide provides comprehensive examples and usage patterns for HPyX, the Python bindings for the HPX C++ Parallelism Library. HPyX enables high-performance parallel computing in Python by leveraging HPX's advanced parallel execution capabilities.
 
+!!! note "v1 API"
+    HPyX v1 introduces a new runtime lifecycle — the HPX runtime now **auto-initializes** on first use. `hpyx.init()` replaces the old `HPXRuntime(...)` kwargs pattern.
+    See [Runtime Management](#runtime-management) for the full details.
+
 ## Table of Contents
 
 1. [Getting Started](#getting-started)
 2. [Runtime Management](#runtime-management)
-3. [Asynchronous Programming with Futures](#asynchronous-programming-with-futures)
-4. [Parallel Processing with for_loop](#parallel-processing-with-for_loop)
-5. [Working with NumPy](#working-with-numpy)
-6. [Error Handling](#error-handling)
-7. [Performance Considerations](#performance-considerations)
-8. [Best Practices](#best-practices)
+3. [Configuration](#configuration)
+4. [Diagnostics](#diagnostics)
+5. [Asynchronous Programming with Futures](#asynchronous-programming-with-futures)
+6. [Parallel Processing with for_loop](#parallel-processing-with-for_loop)
+7. [Working with NumPy](#working-with-numpy)
+8. [Error Handling](#error-handling)
+9. [Performance Considerations](#performance-considerations)
+10. [Best Practices](#best-practices)
 
 ## Getting Started
 
 HPyX provides a clean Python interface to HPX's parallel computing capabilities. The main components are:
 
-- `HPXRuntime`: Manages the HPX runtime lifecycle
-- `hpyx.futures.submit`: Submit functions for asynchronous execution
-- `hpyx.multiprocessing.for_loop`: Parallel iteration over collections
+- `hpyx.init()` / `hpyx.shutdown()` / `hpyx.is_running()` — runtime lifecycle
+- `HPXRuntime` — optional context manager for explicit scoping
+- `hpyx.config` — environment-variable-driven configuration
+- `hpyx.debug` — worker thread diagnostics
+- `hpyx.futures.submit` — submit functions for asynchronous execution
+- `hpyx.multiprocessing.for_loop` — parallel iteration over collections
 
 ### Basic Import
 
 ```python
 import hpyx
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 from hpyx.multiprocessing import for_loop
 ```
 
 ## Runtime Management
 
-The HPX runtime must be initialized before using any HPyX functionality. The `HPXRuntime` class provides a context manager for proper runtime lifecycle management.
+### Auto-initialization (recommended)
 
-### Basic Runtime Usage
-
-```python
-from hpyx.runtime import HPXRuntime
-
-# Using context manager (recommended)
-with HPXRuntime():
-    # Your parallel code here
-    pass
-```
-
-### Runtime Configuration
-
-The `HPXRuntime` class accepts several configuration parameters:
+In v1, HPyX **auto-initializes** the HPX runtime the first time any API that needs it is called. You do not need to call `hpyx.init()` explicitly unless you want to configure thread count before the first use.
 
 ```python
-with HPXRuntime(
-    run_hpx_main=True,           # Execute hpx_main
-    allow_unknown=True,          # Allow unknown command line options
-    aliasing=False,              # Enable HPX short options
-    os_threads="auto",           # Number of OS threads ("auto" or integer)
-    diagnostics_on_terminate=False,  # Print diagnostics on forced terminate
-    tcp_enable=False             # Enable TCP parcelport
-):
-    # Your code here
-    pass
+from hpyx.futures import submit
+
+# Runtime starts automatically on first submit
+future = submit(lambda: 42)
+print(future.get())  # 42
 ```
 
-### Example: Basic Runtime Setup
+### Explicit initialization
+
+Call `hpyx.init()` before any parallel work if you want to control the thread count or pass custom HPX config strings:
 
 ```python
-from hpyx.runtime import HPXRuntime
+import hpyx
 
-def my_computation():
-    return sum(range(1000000))
-
-# Initialize HPX runtime and run computation
-with HPXRuntime():
-    result = my_computation()
-    print(f"Result: {result}")
+hpyx.init(os_threads=8)          # use 8 HPX worker threads
+# or with extra HPX cfg strings:
+hpyx.init(os_threads=4, cfg=["hpx.stacks.small_size=0x20000"])
 ```
+
+`hpyx.init()` is **idempotent** — calling it multiple times with the same arguments is a no-op. Calling it with *different* arguments after the runtime is already running raises `RuntimeError` (HPX cannot be reconfigured in-process).
+
+```python
+hpyx.init(os_threads=4)
+hpyx.init(os_threads=4)  # OK — no-op
+hpyx.init(os_threads=8)  # RuntimeError: already started with different config
+```
+
+### Querying runtime state
+
+```python
+import hpyx
+
+print(hpyx.is_running())  # True once started, False before first init
+```
+
+### Shutdown
+
+HPyX registers an `atexit` handler on first start, so **you normally do not need to call `hpyx.shutdown()` explicitly**. It will run automatically when the Python process exits.
+
+If you need to force an early shutdown (e.g., in a test harness):
+
+```python
+hpyx.shutdown()
+# HPX cannot restart within the same process after shutdown
+```
+
+!!! warning "HPX cannot restart"
+    Once `hpyx.shutdown()` is called (or the atexit handler fires), calling `hpyx.init()` again in the same process raises `RuntimeError`. Plan your process lifecycle accordingly.
+
+### HPXRuntime context manager
+
+`HPXRuntime` is an optional convenience wrapper. It calls `hpyx.init()` on `__enter__` and is a no-op on `__exit__` — it does **not** shut the runtime down when the `with` block exits (HPX cannot restart).
+
+```python
+from hpyx import HPXRuntime
+
+with HPXRuntime(os_threads=4):
+    # runtime is guaranteed to be running here
+    from hpyx.futures import submit
+    future = submit(lambda: "hello from HPX")
+    print(future.get())
+
+# runtime is still running here — atexit owns shutdown
+print(hpyx.is_running())  # True
+```
+
+`HPXRuntime` is most useful when you want to be explicit about the startup point in a script or test, or for backward compatibility with v0.x code.
+
+## Configuration
+
+### Environment variables
+
+HPyX reads configuration from environment variables at runtime startup. These take effect when `hpyx.init()` (or auto-init) first runs.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `HPYX_OS_THREADS` | int | `None` (HPX default) | Number of HPX worker OS threads |
+| `HPYX_CFG` | str | `""` | Semicolon-separated HPX config strings |
+| `HPYX_AUTOINIT` | bool | `true` | Set to `0`/`false` to disable auto-init |
+| `HPYX_TRACE_PATH` | str | `None` | Path for JSONL trace output (v1.x) |
+
+**Precedence:** explicit `hpyx.init()` kwargs > environment variables > built-in defaults.
+
+```bash
+# Run with 16 HPX threads
+HPYX_OS_THREADS=16 python my_script.py
+
+# Disable auto-init (require explicit hpyx.init() call)
+HPYX_AUTOINIT=0 python my_script.py
+
+# Pass HPX config strings
+HPYX_CFG="hpx.stacks.small_size=0x20000;hpx.os_threads!=4" python my_script.py
+```
+
+### Reading config programmatically
+
+```python
+from hpyx import config
+
+# See all defaults
+print(config.DEFAULTS)
+# {'os_threads': None, 'cfg': [], 'autoinit': True, 'trace_path': None}
+
+# Read current env-var layer
+cfg = config.from_env()
+print(cfg["os_threads"])   # e.g. 8 if HPYX_OS_THREADS=8 is set, else None
+```
+
+### Disabling auto-init
+
+Set `HPYX_AUTOINIT=0` to require an explicit `hpyx.init()` call before any HPyX API is used. This is useful in library code where you want the caller to control when the runtime starts.
+
+```python
+# With HPYX_AUTOINIT=0 in the environment:
+import hpyx
+from hpyx.futures import submit
+
+# This would raise RuntimeError without an explicit init:
+hpyx.init(os_threads=4)  # must come first
+
+future = submit(lambda: 42)
+print(future.get())
+```
+
+## Diagnostics
+
+The `hpyx.debug` module exposes worker thread introspection.
+
+```python
+import hpyx
+from hpyx import debug
+
+hpyx.init(os_threads=4)
+
+# Number of HPX worker OS threads in the default pool
+print(debug.get_num_worker_threads())  # 4
+
+# Thread id of the calling thread (-1 if not an HPX worker thread)
+print(debug.get_worker_thread_id())    # -1 (called from main Python thread)
+```
+
+`get_worker_thread_id()` returns `-1` when called from a non-HPX thread (e.g., the Python main thread or a `threading.Thread`). When called from within an HPX task it returns the 0-based worker index.
+
+!!! note "Tracing"
+    `debug.enable_tracing(path)` and `debug.disable_tracing()` are stubbed in v1.0 and raise `NotImplementedError`. Full JSONL-output tracing ships in v1.x (Plan 4).
 
 ## Asynchronous Programming with Futures
 
@@ -83,46 +198,33 @@ HPyX provides futures-based asynchronous programming through the `submit` functi
 ### Basic Future Usage
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def add(a, b):
     return a + b
 
-with HPXRuntime():
-    # Submit function for asynchronous execution
-    future = submit(add, 5, 3)
-    
-    # Get the result (blocks until completion)
-    result = future.get()
-    print(f"5 + 3 = {result}")  # Output: 5 + 3 = 8
+# Runtime auto-initializes on first submit
+future = submit(add, 5, 3)
+result = future.get()
+print(f"5 + 3 = {result}")  # Output: 5 + 3 = 8
 ```
 
 ### Multiple Futures
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def square(x):
     return x * x
 
-with HPXRuntime():
-    # Submit multiple tasks
-    futures = []
-    for i in range(5):
-        future = submit(square, i)
-        futures.append(future)
-    
-    # Collect results
-    results = [future.get() for future in futures]
-    print(f"Squares: {results}")  # Output: Squares: [0, 1, 4, 9, 16]
+futures = [submit(square, i) for i in range(5)]
+results = [f.get() for f in futures]
+print(f"Squares: {results}")  # Output: Squares: [0, 1, 4, 9, 16]
 ```
 
 ### Complex Data Types
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def process_data(data_dict):
@@ -132,25 +234,20 @@ def process_data(data_dict):
         'avg': sum(data_dict['values']) / len(data_dict['values'])
     }
 
-with HPXRuntime():
-    input_data = {'values': [1, 2, 3, 4, 5]}
-    future = submit(process_data, input_data)
-    result = future.get()
-    print(f"Statistics: {result}")
-    # Output: Statistics: {'sum': 15, 'count': 5, 'avg': 3.0}
+input_data = {'values': [1, 2, 3, 4, 5]}
+future = submit(process_data, input_data)
+result = future.get()
+print(f"Statistics: {result}")
+# Output: Statistics: {'sum': 15, 'count': 5, 'avg': 3.0}
 ```
 
 ### Lambda Functions
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
-with HPXRuntime():
-    # Using lambda functions
-    future = submit(lambda x: x ** 2 + 2 * x + 1, 5)
-    result = future.get()
-    print(f"Result: {result}")  # Output: Result: 36
+future = submit(lambda x: x ** 2 + 2 * x + 1, 5)
+print(future.get())  # 36
 ```
 
 ## Parallel Processing with for_loop
@@ -160,7 +257,6 @@ The `for_loop` function provides parallel iteration over collections, applying a
 ### Basic for_loop Usage
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 
 def double(x):
@@ -175,7 +271,6 @@ with HPXRuntime():
 ### Execution Policies
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 
 def increment(x):
@@ -194,7 +289,6 @@ with HPXRuntime():
 ### String Processing
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 
 def to_uppercase(s):
@@ -210,7 +304,6 @@ with HPXRuntime():
 ### Complex Object Transformation
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 
 def update_record(record):
@@ -234,7 +327,6 @@ with HPXRuntime():
 ### Mathematical Operations
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 import math
 
@@ -256,7 +348,6 @@ HPyX integrates well with NumPy arrays, enabling high-performance numerical comp
 
 ```python
 import numpy as np
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def array_statistics(arr):
@@ -283,7 +374,6 @@ with HPXRuntime():
 
 ```python
 import numpy as np
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def matrix_multiply(a, b):
@@ -315,7 +405,6 @@ with HPXRuntime():
 
 ```python
 import numpy as np
-from hpyx.runtime import HPXRuntime
 from hpyx.multiprocessing import for_loop
 
 def normalize_element(x):
@@ -338,7 +427,6 @@ with HPXRuntime():
 
 ```python
 import numpy as np
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def process_large_array(size):
@@ -378,7 +466,6 @@ Proper error handling is essential when working with asynchronous operations and
 ### Exception Handling with Futures
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def risky_operation(x):
@@ -409,7 +496,6 @@ with HPXRuntime():
 ### Runtime Initialization Errors
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def safe_computation():
@@ -429,7 +515,6 @@ if result:
 ### Robust Error Handling Pattern
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 import traceback
 
@@ -507,7 +592,6 @@ for error in errors:
 ### Optimal Threading Configuration
 
 ```python
-from hpyx.runtime import HPXRuntime
 import time
 import multiprocessing
 
@@ -558,7 +642,6 @@ for threads, time_taken in results.items():
 
 ```python
 import numpy as np
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def process_chunk(chunk_data):
@@ -570,24 +653,23 @@ def process_chunk(chunk_data):
 def memory_efficient_processing(total_size, chunk_size=10000):
     """Process large datasets in chunks to manage memory usage."""
     
-    with HPXRuntime():
-        # Generate data in chunks
-        chunk_futures = []
+    # Generate data in chunks
+    chunk_futures = []
+    
+    for start in range(0, total_size, chunk_size):
+        end = min(start + chunk_size, total_size)
+        chunk = np.random.random(end - start)
         
-        for start in range(0, total_size, chunk_size):
-            end = min(start + chunk_size, total_size)
-            chunk = np.random.random(end - start)
-            
-            future = submit(process_chunk, chunk)
-            chunk_futures.append(future)
-        
-        # Collect results
-        total_sum = 0
-        for future in chunk_futures:
-            chunk_sum = future.get()
-            total_sum += chunk_sum
-        
-        return total_sum
+        future = submit(process_chunk, chunk)
+        chunk_futures.append(future)
+    
+    # Collect results
+    total_sum = 0
+    for future in chunk_futures:
+        chunk_sum = future.get()
+        total_sum += chunk_sum
+    
+    return total_sum
 
 # Process 1 million elements in chunks
 result = memory_efficient_processing(1000000, chunk_size=50000)
@@ -610,7 +692,6 @@ with HPXRuntime():
 ### 2. Handle Exceptions Gracefully
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def reliable_computation(data):
@@ -641,7 +722,6 @@ task_queue = deque()
 ### 4. Batch Operations When Possible
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def batch_processing(items, batch_size=100):
@@ -650,22 +730,21 @@ def batch_processing(items, batch_size=100):
     def process_batch(batch):
         return [item * 2 for item in batch]
     
-    with HPXRuntime():
-        futures = []
-        
-        # Create batches
-        for i in range(0, len(items), batch_size):
-            batch = items[i:i + batch_size]
-            future = submit(process_batch, batch)
-            futures.append(future)
-        
-        # Collect results
-        results = []
-        for future in futures:
-            batch_result = future.get()
-            results.extend(batch_result)
-        
-        return results
+    futures = []
+    
+    # Create batches
+    for i in range(0, len(items), batch_size):
+        batch = items[i:i + batch_size]
+        future = submit(process_batch, batch)
+        futures.append(future)
+    
+    # Collect results
+    results = []
+    for future in futures:
+        batch_result = future.get()
+        results.extend(batch_result)
+    
+    return results
 
 # Process large list efficiently
 large_list = list(range(10000))
@@ -676,7 +755,6 @@ processed = batch_processing(large_list, batch_size=500)
 
 ```python
 import time
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 
 def measure_performance(func, *args, **kwargs):
@@ -687,9 +765,8 @@ def measure_performance(func, *args, **kwargs):
     return result, elapsed
 
 def parallel_computation(n):
-    with HPXRuntime():
-        future = submit(lambda: sum(range(n)))
-        return future.get()
+    future = submit(lambda: sum(range(n)))
+    return future.get()
 
 def sequential_computation(n):
     return sum(range(n))
@@ -708,7 +785,6 @@ print(f"Speedup: {sequential_time / parallel_time:.2f}x")
 ### 6. Design for Scalability
 
 ```python
-from hpyx.runtime import HPXRuntime
 from hpyx.futures import submit
 import multiprocessing
 
@@ -723,18 +799,17 @@ def scalable_computation(data, max_workers=None):
     def process_chunk(chunk):
         return sum(x * x for x in chunk)
     
-    with HPXRuntime(os_threads=max_workers):
-        futures = []
-        
-        # Divide work into chunks
-        for i in range(0, len(data), chunk_size):
-            chunk = data[i:i + chunk_size]
-            future = submit(process_chunk, chunk)
-            futures.append(future)
-        
-        # Combine results
-        total = sum(future.get() for future in futures)
-        return total
+    futures = []
+    
+    # Divide work into chunks
+    for i in range(0, len(data), chunk_size):
+        chunk = data[i:i + chunk_size]
+        future = submit(process_chunk, chunk)
+        futures.append(future)
+    
+    # Combine results
+    total = sum(future.get() for future in futures)
+    return total
 
 # Automatically scale to available cores
 data = list(range(100000))


### PR DESCRIPTION
## Summary

- Updates `docs/usage.md` to document the new v1 runtime API (`hpyx.init`, `hpyx.shutdown`, `hpyx.is_running`, env vars, `hpyx.config`, `hpyx.debug`) which landed in #148 but whose docs missed the merge window
- Adds `docs/architecture-decisions.md` with 8 ADR entries recording the Phase 0 design choices
- Updates `docs/index.md` Getting Started example to the v1 auto-init pattern

## Changes

**`docs/usage.md`**
- Rewrites Runtime Management section: auto-init, `hpyx.init()` idempotency, `hpyx.shutdown()`, `HPXRuntime` as optional backward-compat wrapper, atexit-owned shutdown
- New Configuration section: `HPYX_OS_THREADS`, `HPYX_CFG`, `HPYX_AUTOINIT`, `HPYX_TRACE_PATH` env vars; `hpyx.config.from_env()` usage
- New Diagnostics section: `hpyx.debug.get_num_worker_threads()`, `get_worker_thread_id()`, tracing stub note
- Removes old `HPXRuntime(run_hpx_main=..., allow_unknown=..., ...)` kwargs from all examples (those params no longer exist in v1)
- Simplifies all code examples to use auto-init (no unnecessary `with HPXRuntime():` wrappers)

**`docs/architecture-decisions.md`** (new)
- 8 ADR entries for Phase 0: `src/_core/` layout, `_core.runtime` submodule, GIL fix, `g_stopped` restart guard, atexit shutdown, `_runtime` as single init authority, `CMakePresets.json` profile preset, `hpyx.config` as pure-Python layer, `enable_tracing` stub

**`docs/index.md`**
- Updated Getting Started example to v1 auto-init (`submit(...)` without context manager)
- Added Architecture Decisions section link

**`docs/.nav.yml`**
- Added `architecture-decisions.md` to nav under Overview

## Test plan

- [x] `mkdocs build` passes (3.11s, no errors — pre-existing INFO warnings about unlisted codebase-analysis/plans/specs pages are unchanged)
- [x] Verify rendered docs on ReadTheDocs preview show the new Runtime Management, Configuration, and Diagnostics sections
- [x] Verify Architecture Decisions page renders correctly in nav

## Related

Docs follow-up to #148 (HPyX v1 Phase 0 — Foundation)